### PR TITLE
Fix: Skip Claude authentication for non-Claude commands

### DIFF
--- a/cco
+++ b/cco
@@ -187,6 +187,22 @@ find_claude_config_dir() {
 	echo "$primary_dir"
 }
 
+# Check if Claude authentication is needed based on the command being run
+needs_claude_authentication() {
+	# If we're running a custom command (not Claude), skip Claude authentication
+	if [[ -n "$command_flag" || -n "$CCO_COMMAND" ]]; then
+		return 1  # Don't need Claude auth
+	fi
+	
+	# If we're in shell mode, we don't need Claude authentication
+	if [[ "$shell_mode" = true ]]; then
+		return 1  # Don't need Claude auth
+	fi
+	
+	# Otherwise we need Claude authentication
+	return 0  # Need Claude auth
+}
+
 # Verify Claude Code authentication is available
 verify_claude_authentication() {
 	log "Verifying Claude Code authentication..."
@@ -1513,7 +1529,10 @@ main() {
 		check_docker_dependencies
 	fi
 	
-	verify_claude_authentication
+	# Only verify Claude authentication if we need it
+	if needs_claude_authentication; then
+		verify_claude_authentication
+	fi
 
 	# Handle --pull flag first
 	if [[ "$pull_image" = true ]]; then


### PR DESCRIPTION
This PR fixes an issue where commands like `cco codex` required Claude Code authentication even though they don't actually use Claude Code.

## Problem
The `cco codex` command was failing with authentication errors because it was checking for Claude Code credentials even though it runs OpenAI Codex, not Claude Code.

## Solution
- Added a `needs_claude_authentication()` function to determine when Claude authentication is actually required
- Skip authentication check for:
  - Custom commands (`--command` flag or `CCO_COMMAND` env var)
  - Shell mode (`cco shell`)
  - Any non-Claude commands like `codex`
- Preserve authentication requirement for actual Claude Code usage

## Testing
- `cco codex --version` now works without Claude Code authentication
- `cco shell echo hello` works without Claude Code authentication  
- `cco --command python3` works without Claude Code authentication
- Regular Claude Code commands still require authentication (when implemented)

## Backwards Compatibility
This change is fully backwards compatible and only removes unnecessary authentication checks for commands that don't need them.