### PR TITLE
Fix unbound variable errors in sandbox script

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -129,20 +129,20 @@ run_linux() {
 	# Helper temp resources for deny overlays
 	cleanup_paths=()
 	cleanup_overlays() {
-		for p in "${cleanup_paths[@]}"; do
+		for p in "${cleanup_paths[@]+"${cleanup_paths[@]}"}"; do
 			if [[ -n "$p" && -e "$p" ]]; then
 				rm -rf "$p"
 			fi
 		done
 	}
 
-	for ap in "${write_paths[@]}"; do
+	for ap in "${write_paths[@]+"${write_paths[@]}"}"; do
 		# Ensure targets exist so bind succeeds
 		if [[ ! -d "$ap" && ! -e "$ap" ]]; then : >"$ap"; fi
 		args+=(--bind "$ap" "$ap")
 	done
 
-	for ap in "${ro_paths[@]}"; do
+	for ap in "${ro_paths[@]+"${ro_paths[@]}"}"; do
 		if [[ -d "$ap" ]]; then
 			args+=(--ro-bind "$ap" "$ap")
 		else
@@ -151,7 +151,7 @@ run_linux() {
 		fi
 	done
 
-	for ap in "${deny_paths[@]}"; do
+	for ap in "${deny_paths[@]+"${deny_paths[@]}"}"; do
 		if [[ -d "$ap" ]]; then
 			empty_dir=$(mktemp -d)
 			cleanup_paths+=("$empty_dir")
@@ -182,13 +182,13 @@ run_macos() {
 	}
 
 	# Ensure any whitelisted *files* exist so Seatbelt can actually write to them
-	for ap in "${write_paths[@]}"; do
+	for ap in "${write_paths[@]+"${write_paths[@]}"}"; do
 		if [[ ! -d "$ap" && ! -e "$ap" ]]; then : >"$ap"; fi
 	done
-	for ap in "${ro_paths[@]}"; do
+	for ap in "${ro_paths[@]+"${ro_paths[@]}"}"; do
 		if [[ ! -d "$ap" && ! -e "$ap" ]]; then : >"$ap"; fi
 	done
-	for ap in "${deny_paths[@]}"; do
+	for ap in "${deny_paths[@]+"${deny_paths[@]}"}"; do
 		if [[ ! -d "$ap" && ! -e "$ap" ]]; then : >"$ap"; fi
 	done
 
@@ -203,7 +203,7 @@ run_macos() {
 		echo "DEBUG: Seatbelt policy file: $policy_file" >&2
 		echo "DEBUG: Write paths being added:" >&2
 		printf "  PWD: %s\n" "$PWD_ABS" >&2
-		for ap in "${write_paths[@]}"; do
+		for ap in "${write_paths[@]+"${write_paths[@]}"}"; do
 			printf "  Additional: %s\n" "$ap" >&2
 		done
 		keep_policy=true
@@ -229,7 +229,7 @@ run_macos() {
 		fi
 		
 		# 2. Additional paths passed via -w flags
-		for ap in "${write_paths[@]}"; do
+		for ap in "${write_paths[@]+"${write_paths[@]}"}"; do
 			if [[ -d "$ap" ]]; then
 				printf '(allow file-write* (subpath "%s"))\n' "$(policy_quote "$ap")"
 				if [[ "$safe_mode" == true ]]; then
@@ -244,7 +244,7 @@ run_macos() {
 		done
 
 		# Read-only paths: allow reads but keep writes denied
-		for ap in "${ro_paths[@]}"; do
+		for ap in "${ro_paths[@]+"${ro_paths[@]}"}"; do
 			if [[ -d "$ap" ]]; then
 				printf '(allow file-read* (subpath "%s"))\n' "$(policy_quote "$ap")"
 			else
@@ -253,7 +253,7 @@ run_macos() {
 		done
 
 		# Deny paths explicitly
-		for ap in "${deny_paths[@]}"; do
+		for ap in "${deny_paths[@]+"${deny_paths[@]}"}"; do
 			if [[ -d "$ap" ]]; then
 				printf '(deny file-read* (subpath "%s"))\n' "$(policy_quote "$ap")"
 				printf '(deny file-write* (subpath "%s"))\n' "$(policy_quote "$ap")"


### PR DESCRIPTION
## Summary

Fixes #11 - resolves bash strict mode errors when arrays are empty.

## Problem

The sandbox script uses `set -euo pipefail` (strict mode) which treats references to empty arrays as "unbound variable" errors. When running the sandbox without `--read-only`, `--write`, or `--deny` flags, the `ro_paths`, `write_paths`, and `deny_paths` arrays remain empty, causing the script to fail with:

```
/Users/XXX/.local/share/cco/sandbox: line 179: ro_paths[@]: unbound variable
```

## Solution

Applied safe array expansion syntax `"${array[@]+"${array[@]}"}"` to all array iterations. This syntax safely handles empty arrays in bash strict mode by:
- Expanding to nothing when the array is empty or unset
- Expanding to all elements when the array has content

## Changes

Fixed **11 locations** across both `run_linux()` and `run_macos()` functions:

**run_linux() function:**
- `cleanup_paths` array in cleanup handler (line 132)
- `write_paths` array iteration (line 139)
- `ro_paths` array iteration (line 145)
- `deny_paths` array iteration (line 154)

**run_macos() function:**
- `write_paths` file creation (line 185)
- `ro_paths` file creation (line 188)
- `deny_paths` file creation (line 191)
- `write_paths` debug output (line 206)

**Seatbelt policy generation:**
- `write_paths` policy rules (line 232)
- `ro_paths` policy rules (line 247)
- `deny_paths` policy rules (line 256)

## Testing

Tested on macOS with the command that originally triggered the error:
```bash
cco "Who are you?"
```

The fix successfully allows the sandbox to run without errors when no path flags are provided.

## Impact

- **No behavior changes** - only fixes the error condition
- **Backward compatible** - works with both empty and populated arrays
- **Comprehensive** - addresses all vulnerable array iterations to prevent similar errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)