### PR TITLE
Whitelist .claude.json.lock and .npm in native sandbox

### DIFF
--- a/cco
+++ b/cco
@@ -833,6 +833,20 @@ run_native_sandbox() {
 	fi
 	sandbox_rules+=("--write" "$HOME/.claude.json")
 
+	# Allow access to .claude.json.lock directory used by Claude's atomic-write
+	# library (steno/write-file-atomic). Without this, mkdir fails with EROFS
+	# in the bwrap sandbox since $HOME is read-only. See #23.
+	if [[ ! -d "$HOME/.claude.json.lock" ]]; then
+		mkdir -p "$HOME/.claude.json.lock"
+	fi
+	sandbox_rules+=("--write" "$HOME/.claude.json.lock")
+
+	# Allow writes to ~/.npm for MCP server operations (npm cache/logs)
+	if [[ ! -d "$HOME/.npm" ]]; then
+		mkdir -p "$HOME/.npm"
+	fi
+	sandbox_rules+=("--write" "$HOME/.npm")
+
 	# Allow writes to project-specific .claude directory
 	if [[ -d "$project_claude_dir" ]]; then
 		sandbox_rules+=("--write" "$project_claude_dir")


### PR DESCRIPTION
Claude Code's atomic-write library creates a .claude.json.lock directory
and temp files as siblings of .claude.json. In the bwrap sandbox, $HOME
is read-only so these operations fail with EROFS. Pre-create and
whitelist .claude.json.lock so the lock acquisition succeeds. Also
whitelist ~/.npm for MCP server npm cache/log writes.

The .claude.json.tmp.* temp files still hit EROFS (unpredictable names
can't be individually bind-mounted), but the fallback direct write
succeeds.

Fixes #23
