### PR TITLE
fix: allow lstat on $HOME and CWD ancestors in safe mode

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -536,6 +536,14 @@ run_macos() {
 		# Optional safe mode: deny reads under $HOME by default, re-allow below
 		if [[ "$safe_mode" == true ]]; then
 			printf '(deny file-read* (subpath "%s"))\n' "$(policy_quote "$HOME")"
+			# Allow lstat/stat on $HOME and ancestor dirs between $HOME and CWD
+			# (needed by Node.js realpathSync and node_modules/.bin PATH walk)
+			local ancestor="$PWD_ABS"
+			while [[ "$ancestor" != "$HOME" && "$ancestor" == "$HOME"/* ]]; do
+				ancestor="$(dirname "$ancestor")"
+				printf '(allow file-read-metadata (literal "%s"))\n' "$(policy_quote "$ancestor")"
+			done
+			printf '(allow file-read-metadata (literal "%s"))\n' "$(policy_quote "$HOME")"
 		fi
 
 		# Deny paths explicitly (BEFORE any allows that might be under them)


### PR DESCRIPTION
Hello 👋

I was trying safe mode and I encountered a crash as soon as claude was starting:

```
$ cco --safe
▶ Starting cco...
▶ Using native sandbox (Seatbelt)
▶ Verifying Claude Code authentication...
▶ Verified Claude Code credentials in macOS Keychain
▶ Claude Code authentication verified
▶ Starting cco with native sandbox...
node:fs:2759
      const stats = binding.lstat(base, true, undefined, true /* throwIfNoEntry */);
                            ^

Error: EPERM: operation not permitted, lstat '/Users/void'
    at realpathSync (node:fs:2759:29)
    at as8 (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:29237)
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:41008
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:1090
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:48773
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:1090
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:9:135
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:1090
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:11:228
    at file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:1090 {
  errno: -1,
  code: 'EPERM',
  syscall: 'lstat',
  path: '/Users/void'
}
```

`--safe` mode denies `file-read*` under `$HOME` via Seatbelt policy. But this blocks stat/lstat on `$HOME` itself and intermediate dirs between `$HOME` and the current working directory.

Based on Claude reading it's own minified source code, at startup `realpathSync(cwd)` is called, which stats every path component to resolve symlinks.

So this change emit `(allow file-read-metadata (literal ...))` for `$HOME` and each ancestor between `$HOME` and the current working directory. `file-read-metadata covers` only stat/lstat/fstat — directory listing and file content reads stay denied, so not giving away the folder content.