### PR TITLE
fix: allow file-read-metadata on $HOME in --safe mode on macOS

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -536,14 +536,11 @@ run_macos() {
 		# Optional safe mode: deny reads under $HOME by default, re-allow below
 		if [[ "$safe_mode" == true ]]; then
 			printf '(deny file-read* (subpath "%s"))\n' "$(policy_quote "$HOME")"
-			# Allow lstat/stat on $HOME and ancestor dirs between $HOME and CWD
-			# (needed by Node.js realpathSync and node_modules/.bin PATH walk)
-			local ancestor="$PWD_ABS"
-			while [[ "$ancestor" != "$HOME" && "$ancestor" == "$HOME"/* ]]; do
-				ancestor="$(dirname "$ancestor")"
-				printf '(allow file-read-metadata (literal "%s"))\n' "$(policy_quote "$ancestor")"
-			done
-			printf '(allow file-read-metadata (literal "%s"))\n' "$(policy_quote "$HOME")"
+			# Allow stat/lstat on all paths under $HOME (but not content reads).
+			# Tools like Node.js call realpathSync which needs lstat on arbitrary
+			# paths, not just CWD ancestors. Content reads (file-read-data) and
+			# xattr reads (file-read-xattr) remain denied.
+			printf '(allow file-read-metadata (subpath "%s"))\n' "$(policy_quote "$HOME")"
 		fi
 
 		# Deny paths explicitly (BEFORE any allows that might be under them)

--- a/tests/test_sandbox.sh
+++ b/tests/test_sandbox.sh
@@ -417,16 +417,6 @@ if [[ "$OS" == "Darwin" ]]; then
 	fi
 	rm -rf "$link_test"
 
-	echo "Test: --safe + --deny blocks stat on denied paths"
-	deny_test="$HOME/.sandbox_deny_test_$$"
-	mkdir -p "$deny_test"
-	if ./sandbox --safe --deny "$deny_test" stat "$deny_test" >/dev/null 2>&1; then
-		fail "--safe + --deny blocks stat on denied paths: stat succeeded"
-	else
-		pass "--safe + --deny blocks stat on denied paths"
-	fi
-	rm -rf "$deny_test"
-
 	echo "Test: --safe denies reading files from ancestor dirs under HOME"
 	ancestor="$PWD"
 	read_blocked=true

--- a/tests/test_sandbox.sh
+++ b/tests/test_sandbox.sh
@@ -417,6 +417,16 @@ if [[ "$OS" == "Darwin" ]]; then
 	fi
 	rm -rf "$link_test"
 
+	echo "Test: --safe + --deny blocks stat on denied paths"
+	deny_test="$HOME/.sandbox_deny_test_$$"
+	mkdir -p "$deny_test"
+	if ./sandbox --safe --deny "$deny_test" stat "$deny_test" >/dev/null 2>&1; then
+		fail "--safe + --deny blocks stat on denied paths: stat succeeded"
+	else
+		pass "--safe + --deny blocks stat on denied paths"
+	fi
+	rm -rf "$deny_test"
+
 	echo "Test: --safe denies reading files from ancestor dirs under HOME"
 	ancestor="$PWD"
 	read_blocked=true

--- a/tests/test_sandbox.sh
+++ b/tests/test_sandbox.sh
@@ -396,6 +396,27 @@ if [[ "$OS" == "Darwin" ]]; then
 		skip "--safe ancestor test: CWD not under HOME"
 	fi
 
+	echo "Test: --safe allows lstat on non-ancestor paths under HOME"
+	non_ancestor="$HOME/.sandbox_meta_test_$$"
+	mkdir -p "$non_ancestor/deep/path"
+	if ./sandbox --safe stat "$non_ancestor/deep/path" >/dev/null 2>&1; then
+		pass "--safe allows lstat on non-ancestor paths under HOME"
+	else
+		fail "--safe allows lstat on non-ancestor paths under HOME"
+	fi
+	rm -rf "$non_ancestor"
+
+	echo "Test: --safe allows readlink on symlinks under HOME"
+	link_test="$HOME/.sandbox_link_test_$$"
+	mkdir -p "$link_test"
+	ln -s /tmp "$link_test/tmplink"
+	if ./sandbox --safe readlink "$link_test/tmplink" >/dev/null 2>&1; then
+		pass "--safe allows readlink on symlinks under HOME"
+	else
+		fail "--safe allows readlink on symlinks under HOME"
+	fi
+	rm -rf "$link_test"
+
 	echo "Test: --safe denies reading files from ancestor dirs under HOME"
 	ancestor="$PWD"
 	read_blocked=true


### PR DESCRIPTION
## Summary

Fixes #49

`--safe` mode on macOS blocks `file-read-metadata` (stat/lstat) on paths under `$HOME` that are not CWD ancestors, breaking Node.js and other tools that call `realpathSync` or `lstat` on arbitrary `$HOME` subpaths.

- Replace per-ancestor `(allow file-read-metadata (literal ...))` rules with a single `(allow file-read-metadata (subpath "$HOME"))`
- Add tests for stat/readlink on non-CWD-ancestor paths under `$HOME`

## Problem

The existing `literal` ancestor allows only cover the path from CWD up to `$HOME`:

```scheme
(deny file-read* (subpath "$HOME"))
(allow file-read-metadata (literal "$ancestor_1"))  ;; only CWD ancestors
...
(allow file-read-metadata (literal "$HOME"))
```

Tools like Node.js call `realpathSync` which needs `lstat` on **arbitrary** paths (e.g., `$HOME/.local/share/mise/...`), not just CWD ancestors. These calls fail with `EPERM`.

## Fix

Replace with a single `subpath` allow:

```scheme
(deny file-read* (subpath "$HOME"))
(allow file-read-metadata (subpath "$HOME"))
```

This permits stat/lstat on all paths under `$HOME` while still denying:
- `file-read-data` (file content reads)
- `file-read-xattr` (extended attribute reads)

## Security Considerations

With `subpath`, a sandboxed process can stat any path under `$HOME` (existence, size, mtime, permissions). This is acceptable because:

- `--safe` mode already uses `(allow default)`, full network access, env var inheritance, and Mach port access — it's not a hostile-adversary containment sandbox
- Linux `--safe` mode (tmpfs overlay) allows stat on the mount — this makes macOS consistent
- The previous `literal` approach already leaked metadata for CWD ancestors

## Test Plan

Added to `tests/test_sandbox.sh` (macOS safe mode section):

- [x] `stat` on non-CWD-ancestor path under `$HOME` — should succeed
- [x] `readlink` on symlink under `$HOME` (non-ancestor) — should succeed
- [x] Existing tests preserved: content reads and directory listings still denied

Verified locally:
- [x] `shellcheck sandbox` — clean
- [x] `shellcheck tests/test_sandbox.sh` — clean
- [x] `shfmt -d sandbox` — no diff
- [x] `shfmt -d tests/test_sandbox.sh` — no diff
- [x] `make test` on macOS — 35/35 passed, 0 failed