### PR TITLE
fix: allow file-read-metadata on $HOME in --safe mode on macOS

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -547,9 +547,15 @@ run_macos() {
 		# Seatbelt uses LAST-MATCH-WINS, so deny must come before allow exceptions
 		for ap in "${deny_paths[@]+"${deny_paths[@]}"}"; do
 			if [[ -d "$ap" ]]; then
+				if [[ "$safe_mode" == true ]]; then
+					printf '(deny file-read-metadata (subpath "%s"))\n' "$(policy_quote "$ap")"
+				fi
 				printf '(deny file-read* (subpath "%s"))\n' "$(policy_quote "$ap")"
 				printf '(deny file-write* (subpath "%s"))\n' "$(policy_quote "$ap")"
 			else
+				if [[ "$safe_mode" == true ]]; then
+					printf '(deny file-read-metadata (literal "%s"))\n' "$(policy_quote "$ap")"
+				fi
 				printf '(deny file-read* (literal "%s"))\n' "$(policy_quote "$ap")"
 				printf '(deny file-write* (literal "%s"))\n' "$(policy_quote "$ap")"
 			fi

--- a/tests/test_sandbox.sh
+++ b/tests/test_sandbox.sh
@@ -417,6 +417,38 @@ if [[ "$OS" == "Darwin" ]]; then
 	fi
 	rm -rf "$link_test"
 
+	echo "Test: --safe with --deny blocks metadata on denied directories"
+	safe_deny_test="$HOME/.sandbox_safe_deny_test_$$"
+	mkdir -p "$safe_deny_test/denied/inside"
+	echo "secret" >"$safe_deny_test/denied/inside/file.txt"
+	if ./sandbox --safe --deny "$safe_deny_test/denied" stat "$safe_deny_test/denied" >/dev/null 2>&1; then
+		fail "--safe with --deny blocks metadata on denied directories"
+	else
+		pass "--safe with --deny blocks metadata on denied directories"
+	fi
+
+	echo "Test: --safe with --deny blocks metadata on denied files"
+	if ./sandbox --safe --deny "$safe_deny_test/denied" stat "$safe_deny_test/denied/inside/file.txt" >/dev/null 2>&1; then
+		fail "--safe with --deny blocks metadata on denied files"
+	else
+		pass "--safe with --deny blocks metadata on denied files"
+	fi
+
+	echo "Test: --safe with --deny still blocks file reads"
+	if ./sandbox --safe --deny "$safe_deny_test/denied" cat "$safe_deny_test/denied/inside/file.txt" >/dev/null 2>&1; then
+		fail "--safe with --deny still blocks file reads"
+	else
+		pass "--safe with --deny still blocks file reads"
+	fi
+
+	echo "Test: --safe with --deny still blocks directory listing"
+	if ./sandbox --safe --deny "$safe_deny_test/denied" ls "$safe_deny_test/denied" >/dev/null 2>&1; then
+		fail "--safe with --deny still blocks directory listing"
+	else
+		pass "--safe with --deny still blocks directory listing"
+	fi
+	rm -rf "$safe_deny_test"
+
 	echo "Test: --safe denies reading files from ancestor dirs under HOME"
 	ancestor="$PWD"
 	read_blocked=true

--- a/tests/test_seatbelt_precedence.sh
+++ b/tests/test_seatbelt_precedence.sh
@@ -151,6 +151,39 @@ rm -f "$POLICY"
 rm -rf "$WRITE_DIR"
 
 #
+# Test 5: Explicit metadata deny overrides broad metadata allow when it comes later
+#
+echo ""
+echo "--- Test 5: Metadata precedence (allow HOME metadata THEN deny child metadata) ---"
+META_DIR="$HOME/.seatbelt_metadata_test_$$"
+mkdir -p "$META_DIR/home/child"
+echo "secret" >"$META_DIR/home/child/file.txt"
+
+POLICY=$(mktemp)
+cat >"$POLICY" <<EOF
+(version 1)
+(allow default)
+(deny file-read* (subpath "$META_DIR/home"))
+(allow file-read-metadata (subpath "$META_DIR/home"))
+(deny file-read-metadata (subpath "$META_DIR/home/child"))
+EOF
+
+if sandbox-exec -f "$POLICY" stat "$META_DIR/home/child" >/dev/null 2>&1; then
+	fail "Explicit metadata deny should block stat on the denied child path"
+else
+	pass "Explicit metadata deny overrides the broad metadata allow"
+fi
+
+if sandbox-exec -f "$POLICY" cat "$META_DIR/home/child/file.txt" 2>/dev/null; then
+	fail "Content reads should remain denied for the child path"
+else
+	pass "Content reads stay denied with the metadata override"
+fi
+
+rm -f "$POLICY"
+rm -rf "$META_DIR"
+
+#
 # Summary
 #
 echo ""


### PR DESCRIPTION
This is a follow-up to PR #50 which fixed `file-read-metadata` on $HOME in `--safe` mode.

## What changed since PR #50

PR #50 added a broad `file-read-metadata` allow for $HOME, fixing issue #49 where legitimate home directory path resolution was blocked. However, it didn't preserve the metadata denial for `--deny` paths.

This PR adds two commits:

**Commit 1: Preserve macOS --safe deny metadata checks**

- Emit explicit `file-read-metadata` denies for `--deny` paths while in `--safe` mode
- Keep the broad $HOME metadata allow from PR #50 so non-ancestor stat still works
- Leave the existing allow-inside-deny ordering intact for later path-specific exceptions

**Commit 2: Restore macOS --safe metadata regression coverage**

- Re-add safe-mode deny-path checks so denied files and directories cannot be stat'ed
- Keep PR #50's non-ancestor stat and readlink coverage in the sandbox test script
- Add a focused Seatbelt precedence test for explicit `file-read-metadata` denies

## Testing

All existing tests pass. New tests cover the `--deny` metadata blocking in `--safe` mode and verify Seatbelt semantics.