### PR TITLE
OAuth: replace home-write persistence with startup repair model

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ cco --deny-path ~/Downloads
 - `--docker-socket` (experimental): Binds the host Docker socket into the sandbox so Claude can control Docker on your machine. This defeats the isolation barrier—avoid unless you explicitly need host Docker access.
 - `--image IMAGE` / `--docker-image IMAGE` (Docker only): Runs `cco` against a specific Docker image instead of the default managed `cco:latest` image. This is useful if you `docker commit` a known-good persistent container yourself and want later `cco` runs to start from that image. With `--pull`, `cco` pulls the chosen image first.
 - `--force-docker-bridge-network` (Docker only): Force bridge networking instead of host networking. By default cco uses `--network=host` when available (Linux, OrbStack). Use this if you need port isolation or want explicit `-p` port forwarding.
-- `--yes` / `-y`: Auto-accept startup recovery prompts such as OAuth refresh or macOS Keychain unlock before `cco` starts.
+- `--yes` / `-y`: Auto-accept startup recovery prompts such as macOS Keychain unlock before `cco` starts. OAuth tokens that expire soon are refreshed automatically before sandbox startup when the selected backend cannot safely persist an in-sandbox refresh.
 - `--allow-oauth-refresh` (experimental): Gives the container write access to your Claude credentials so refreshed tokens sync back to the host. Malicious prompts could corrupt or replace those credentials.
 - `--persist` (Docker only, opt-in): Reuses the default persistent container for the current repo instead of starting fresh each run. `cco` starts it for the invocation and stops it again when the run ends.
 - `--persist=NAME` or `--persist NAME`: Selects a specific persistent session for the current repo so you can keep multiple reusable container filesystems side by side.
@@ -532,10 +532,10 @@ cco restore-creds backup-file.json  # Restore from specific backup
 - On macOS over SSH, `cco` will offer to unlock your login keychain if it cannot read Claude credentials. Use `--yes` to auto-accept that recovery step.
 
 **Token expiration**
-- If you get authentication errors, your OAuth token may have expired
-- The containerized environment prevents automatic token refresh by default
-- **Solution**: Run `claude` directly (outside `cco`) to re-authenticate, then retry with `cco`
-- For automatic token refresh, the beta `--allow-oauth-refresh` flag will sync container credentials back to your host. Only use it if you accept the additional credential tampering risk.
+- If you get authentication errors, your OAuth token may have expired or need a fresh browser login
+- `cco` checks stored OAuth expiry before sandbox startup. When the selected backend cannot safely persist an in-sandbox refresh and the token expires soon, `cco` runs one fixed plain-Claude refresh on the host before entering the sandbox.
+- **Fallback**: Run `claude` directly (outside `cco`) to re-authenticate, then retry with `cco`
+- For in-sandbox refresh sync-back, the beta `--allow-oauth-refresh` flag will sync container credentials back to your host. Only use it if you accept the additional credential tampering risk.
 
 **Docker problems**
 - Start Docker daemon
@@ -547,15 +547,15 @@ cco restore-creds backup-file.json  # Restore from specific backup
 
 **Experimental features not working**
 - OAuth refresh (`--allow-oauth-refresh`) is beta, reduces credential isolation, and may have issues
-- Fallback: authenticate directly with `claude` when tokens expire
+- Fallback: authenticate directly with `claude` if the startup refresh cannot recover credentials
 - Use credential backup/restore commands for safety: `cco backup-creds` / `cco restore-creds`
 
 ### Known Issues
 
-**Token expires during active session (macOS)**
-If Claude stops responding with API errors during an active `cco` session, your OAuth token has likely expired mid-session. This is primarily a macOS issue due to credential storage differences.
+**Token expires during active session**
+If Claude stops responding with API errors during an active `cco` session, your OAuth token has likely expired mid-session. `cco` normally refreshes tokens that expire soon before sandbox startup, but a long-running session can still cross the expiry boundary.
 
-**Root cause**: When Claude Code runs inside the Linux container, it cannot directly update the macOS Keychain on the host system where credentials are stored. The OAuth refresh call is "coming from inside the house" but can't reach the host Keychain.
+**Root cause**: Some sandbox backends cannot safely persist Claude's refreshed OAuth credentials back to the host credential store without granting broader credential or home-directory write access. `cco` keeps the sandbox narrow and performs a fixed host-side refresh before startup when it can predict the expiry.
 
 **Workaround**:
 1. Open a new terminal window
@@ -565,9 +565,7 @@ If Claude stops responding with API errors during an active `cco` session, your 
 5. Quit your current `cco` session
 6. Restart with `cco --resume` to pick up the refreshed credentials
 
-**Linux note**: This issue may not affect Linux systems where credentials are file-based and can potentially be updated with `--allow-oauth-refresh` flag, though this needs more testing.
-
-*PRs welcome to investigate cross-platform solutions for seamless credential refresh.*
+For repeated startup failures, run plain `claude` once to confirm the account can refresh or re-login outside the sandbox, then start `cco` again.
 
 **Stdio-based MCP servers not available**
 If Claude reports that stdio-based MCP servers are not found or not working, they need to be installed inside the container. See [MCP Server Support](#mcp-server-support) section for installation instructions.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You should barely notice `cco` is there, except for that reassuring feeling of s
 - **Automatic sandbox selection**: Chooses native OS sandboxing when available, Docker as fallback
 - **Native sandbox (preferred)**: Lightweight, fast startup, direct Keychain access on macOS. Exposes host filesystem read-only by default.
 - **Docker sandbox (fallback)**: Stronger filesystem isolation with container-only filesystem when native tools unavailable
-- **Host file access**: Your project files are accessible so Claude can read and edit them
+- **Host file access**: Your project files and Claude state paths are accessible so Claude can read and edit what it needs
 - **Git worktree support**: Automatically detects git worktrees and whitelists the main repo's `.git` directory so git operations work seamlessly
 - **Network access**: Full host network access for localhost development servers, MCP servers, and web requests
 - **Credential management**: Authentication is handled securely without exposing host credentials
@@ -415,6 +415,7 @@ cd cco
 ### Environment setup
 `cco` passes through everything you need:
 - `ANTHROPIC_API_KEY` - Direct access
+- `CLAUDE_CODE_OAUTH_TOKEN` - Externally managed Claude OAuth token; skips local credential checks and startup refresh
 - Terminal settings (`TERM`, `NO_COLOR`)
 - Git configuration
 - Locale and timezone
@@ -426,6 +427,7 @@ cd cco
 echo "DEBUG=1" > .env
 cco
 ```
+Blank lines, comments, whitespace-prefixed comments, and non-assignment lines in `.env` are ignored so shell-style formatting does not break startup.
 
 ## Requirements
 
@@ -443,7 +445,7 @@ cco
 - **Docker sandbox mode**:
   - **macOS**: Extracts from Keychain and mounts securely
   - **Linux**: Mounts `~/.claude/.credentials.json` or config directory
-- **Environment**: `ANTHROPIC_API_KEY` passed through in both modes
+- **Environment**: `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` passed through in both modes
 
 ## Architecture
 
@@ -458,7 +460,7 @@ Understanding the filesystem isolation differences between sandbox modes:
 | **Native + `--safe`** | Only project + whitelisted | **Strong** | Fast startup | Security + performance balance (experimental) |
 
 **Key Points:**
-- **Native sandbox (default)**: Exposes your entire host filesystem as read-only. Claude can read any file your user can read, but can only write to the project directory.
+- **Native sandbox (default)**: Exposes your entire host filesystem as read-only. Claude can read any file your user can read, but can only write to the project directory, Claude config/state paths, explicitly shared paths, and trusted git worktree metadata when needed.
 - **Docker sandbox**: Only shows explicitly mounted paths. Claude cannot see or read files outside mounted directories.
 - **`--safe` flag** (experimental): Available only with native sandboxing. Hides your `$HOME` directory entirely while keeping fast native performance. May cause some tools to fail if they require access to dotfiles or configuration in `$HOME`.
 
@@ -481,9 +483,9 @@ Understanding the filesystem isolation differences between sandbox modes:
 ### Safety features
 - **Filesystem isolation**: Level depends on sandbox mode
   - **Docker mode**: Only project and explicitly mounted paths visible
-  - **Native mode (default)**: Entire host filesystem visible read-only, project read/write
+  - **Native mode (default)**: Entire host filesystem visible read-only; project, Claude config/state paths, explicitly shared paths, and trusted git worktree metadata are read/write
   - **Native + `--safe`**: Only project and whitelisted paths visible (stronger isolation)
-- **Write protection**: All modes prevent writes outside project directory
+- **Write protection**: All modes prevent writes outside project, Claude state, and explicitly whitelisted paths
 - **Secure credential mounting**: Runtime-only credential access
 - **Fresh session isolation**: Clean environment for each session
 - **Terminal injection protection**: Linux sandbox blocks TIOCSTI/TIOCLINUX attacks via seccomp filtering
@@ -509,8 +511,8 @@ cco "review this pull request"
 ⚠️ **These features are experimental and may have edge cases. Use with caution.**
 
 ```bash
-# OAuth token refresh (EXPERIMENTAL)
-# Allows Claude to refresh expired tokens and sync back to host system
+# OAuth token sync-back (EXPERIMENTAL)
+# Lets sandboxed Claude sync refreshed credentials back to the host
 cco --allow-oauth-refresh "help me code"
 
 # Credential management (EXPERIMENTAL)  
@@ -520,7 +522,7 @@ cco restore-creds                   # Restore from most recent backup
 cco restore-creds backup-file.json  # Restore from specific backup
 ```
 
-**OAuth refresh feature**: Enables bidirectional credential sync when Claude refreshes expired tokens. Uses race condition protection and creates automatic backups.
+**OAuth refresh feature**: `cco` automatically performs a fixed host-side refresh before startup when credentials expire soon and the selected backend cannot safely persist an in-sandbox refresh. The experimental `--allow-oauth-refresh` mode is different: it enables bidirectional credential sync when sandboxed Claude refreshes expired tokens. It uses race condition protection and creates automatic backups.
 
 **Credential management**: Provides manual backup/restore of Claude Code credentials with cross-platform support (macOS Keychain + Linux files).
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ cco --deny-path ~/Downloads
 - `--docker-socket` (experimental): Binds the host Docker socket into the sandbox so Claude can control Docker on your machine. This defeats the isolation barrier—avoid unless you explicitly need host Docker access.
 - `--image IMAGE` / `--docker-image IMAGE` (Docker only): Runs `cco` against a specific Docker image instead of the default managed `cco:latest` image. This is useful if you `docker commit` a known-good persistent container yourself and want later `cco` runs to start from that image. With `--pull`, `cco` pulls the chosen image first.
 - `--force-docker-bridge-network` (Docker only): Force bridge networking instead of host networking. By default cco uses `--network=host` when available (Linux, OrbStack). Use this if you need port isolation or want explicit `-p` port forwarding.
-- `--yes` / `-y`: Auto-accept startup recovery prompts such as macOS Keychain unlock before `cco` starts. OAuth tokens that expire soon are refreshed automatically before sandbox startup when the selected backend cannot safely persist an in-sandbox refresh.
+- `--yes` / `-y`: Auto-accept startup recovery prompts such as macOS Keychain unlock before `cco` starts. OAuth maintenance is automatic when needed and is not controlled by `--yes`.
 - `--allow-oauth-refresh` (experimental): Gives the container write access to your Claude credentials so refreshed tokens sync back to the host. Malicious prompts could corrupt or replace those credentials.
 - `--persist` (Docker only, opt-in): Reuses the default persistent container for the current repo instead of starting fresh each run. `cco` starts it for the invocation and stops it again when the run ends.
 - `--persist=NAME` or `--persist NAME`: Selects a specific persistent session for the current repo so you can keep multiple reusable container filesystems side by side.
@@ -522,7 +522,7 @@ cco restore-creds                   # Restore from most recent backup
 cco restore-creds backup-file.json  # Restore from specific backup
 ```
 
-**OAuth refresh feature**: `cco` automatically performs a fixed host-side refresh before startup when credentials expire soon and the selected backend cannot safely persist an in-sandbox refresh. The experimental `--allow-oauth-refresh` mode is different: it enables bidirectional credential sync when sandboxed Claude refreshes expired tokens. It uses race condition protection and creates automatic backups.
+**OAuth refresh feature**: When the selected backend cannot safely persist an in-sandbox refresh, `cco` repairs already-expired Claude OAuth credentials with a fixed host-side Claude call before startup. If stored credentials are still valid but expire within two hours, `cco` starts Claude normally and runs the host-side refresh in the background. The experimental `--allow-oauth-refresh` mode is different: it enables bidirectional credential sync when sandboxed Claude refreshes expired tokens. It uses race condition protection and creates automatic backups.
 
 **Credential management**: Provides manual backup/restore of Claude Code credentials with cross-platform support (macOS Keychain + Linux files).
 
@@ -535,7 +535,7 @@ cco restore-creds backup-file.json  # Restore from specific backup
 
 **Token expiration**
 - If you get authentication errors, your OAuth token may have expired or need a fresh browser login
-- `cco` checks stored OAuth expiry before sandbox startup. When the selected backend cannot safely persist an in-sandbox refresh and the token expires soon, `cco` runs one fixed plain-Claude refresh on the host before entering the sandbox.
+- `cco` checks stored OAuth expiry before sandbox startup. When the selected backend cannot safely persist an in-sandbox refresh, already-expired credentials are repaired before Claude starts. Valid credentials that expire within two hours are refreshed in the background while startup continues.
 - **Fallback**: Run `claude` directly (outside `cco`) to re-authenticate, then retry with `cco`
 - For in-sandbox refresh sync-back, the beta `--allow-oauth-refresh` flag will sync container credentials back to your host. Only use it if you accept the additional credential tampering risk.
 
@@ -555,9 +555,9 @@ cco restore-creds backup-file.json  # Restore from specific backup
 ### Known Issues
 
 **Token expires during active session**
-If Claude stops responding with API errors during an active `cco` session, your OAuth token has likely expired mid-session. `cco` normally refreshes tokens that expire soon before sandbox startup, but a long-running session can still cross the expiry boundary.
+If Claude stops responding with API errors during an active `cco` session, your OAuth token has likely expired mid-session. `cco` normally refreshes valid tokens that expire within two hours in the background during startup, but a long-running session can still cross the expiry boundary.
 
-**Root cause**: Some sandbox backends cannot safely persist Claude's refreshed OAuth credentials back to the host credential store without granting broader credential or home-directory write access. `cco` keeps the sandbox narrow and performs a fixed host-side refresh before startup when it can predict the expiry.
+**Root cause**: Some sandbox backends cannot safely persist Claude's refreshed OAuth credentials back to the host credential store without granting broader credential or home-directory write access. `cco` keeps the sandbox narrow, repairs already-expired credentials before startup, and performs background host-side refresh for valid credentials that are close to expiry.
 
 **Workaround**:
 1. Open a new terminal window

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Claude Code runs directly on the host system with full user privileges:
 `cco` addresses these vulnerabilities through strict containerization:
 
 ### Enforced Sandbox
-- **Scoped filesystem access**: Claude can read/write the current project directory plus Claude-specific config paths (`~/.claude`, detected config dir, `.claude.json`). In Docker mode no other host paths exist unless you mount them. In native mode both Seatbelt (macOS) and bubblewrap (Linux) expose the entire host filesystem as read-only by default; use `--safe` to hide your `$HOME` directory for better isolation.
+- **Scoped filesystem access**: Claude can read/write the current project directory plus Claude-specific config paths (`~/.claude`, detected config dir, `.claude.json`) and the transient Claude lock/temp paths needed by the CLI. Trusted git worktree metadata is also writable when auto-detected. In Docker mode no other host paths exist unless you mount them. In native mode both Seatbelt (macOS) and bubblewrap (Linux) expose the entire host filesystem as read-only by default; use `--safe` to hide your `$HOME` directory for better isolation.
 - **Directory changes are sandboxed**: `cd /` succeeds, but in Docker mode this is the container's root filesystem (not your host), and in native mode both Seatbelt and bubblewrap deny writes outside the whitelisted paths while still allowing reads of the entire host filesystem.
 - **Process isolation**: Claude's processes are contained within either the container namespace or the native sandbox profile, preventing host-level process injection.
 - **Enhanced safe mode** (experimental): `cco --safe` (native sandbox only) provides stronger filesystem isolation by hiding your `$HOME` directory entirely, leaving only the project directory and explicitly whitelisted paths visible for reads. This significantly reduces exposure compared to the default native sandbox behavior. **Trade-off**: Some tools may fail if they require access to configuration files in `$HOME` - use `--allow-readonly` to selectively expose needed paths.
@@ -52,7 +52,7 @@ Claude Code runs directly on the host system with full user privileges:
 ### Credential Protection
 - **Runtime extraction**: Each session fetches fresh Claude credentials (macOS Keychain or Linux config file) into a temporary location.
 - **Read/write reality**: Claude's config directories (`~/.claude`, detected config dir, `.claude.json`) are mounted read-write so it can persist preferences and session state.
-- **Credential file access**: The credentials JSON is mounted read-only by default, so Claude cannot update tokens unless `--allow-oauth-refresh` is explicitly enabled.
+- **Credential file access**: Docker uses a temporary credentials mount that is read-only by default and becomes read/write only with `--allow-oauth-refresh`. Native backends expose Claude's normal config paths for CLI compatibility, but `cco` treats backends that cannot safely persist an in-sandbox refresh as non-persisting and refreshes near-expiry OAuth credentials before startup instead.
 - **No image persistence**: Credentials are never baked into the Docker image; temporary files are cleaned up after the session.
 - **Startup credential maintenance**: Before sandbox startup, `cco` may run a one-shot plain `claude -p ...` call on the host when stored OAuth credentials expire soon and the chosen sandbox cannot safely sync an in-sandbox refresh back. It may also offer `security unlock-keychain ...` for locked macOS login keychains over SSH.
 - **Consent boundary**: Keychain unlock recovery still runs only after an interactive confirmation, or automatically when `--yes` / `-y` is supplied. The OAuth maintenance refresh is a fixed `cco`-controlled host action before sandbox startup; it does not grant Claude ongoing general Keychain access or widen the sandbox after startup.
@@ -142,11 +142,13 @@ Claude Code runs directly on the host system with full user privileges:
 | `~/.claude` | Read/write | Session state, MCP configs, logs |
 | Detected config directory (`$XDG_CONFIG_HOME/claude` or `~/.claude`) | Read/write | Needed for new Claude CLI defaults |
 | `~/.claude.json` | Read/write | CLI top-level state file |
+| Claude lock/temp paths | Limited write | macOS Seatbelt allows narrow `~/.claude.lock`, `~/.claude.json.lock`, and `~/.claude.json.tmp.*` writes; Linux native does not broadly open `$HOME` for arbitrary sibling creation |
+| Trusted git worktree common dir | Read/write | Auto-added when current directory or immediate child git checkout uses the standard `.git/worktrees/...` layout |
 | `~/.ssh` | Read-only | Exposed so git can use host keys; consider using ssh-agent instead |
 | `~/.gitconfig` | Read-only | Git identity and settings |
 | Temporary credential file | Read-only | Mounted at runtime; becomes read/write only with `--allow-oauth-refresh` |
 | macOS Keychain | No access | Becomes read/write with `--allow-keychain` (CRITICAL security risk) |
-| Other host paths | No access | Unless explicitly mounted via flags |
+| Other host paths | Read-only in native default; no access in Docker | Native `--safe` hides `$HOME` except explicitly shared paths |
 
 **Safe Mode (`--safe`, native only, experimental)**
 - **Provides stronger filesystem isolation**: Hides your entire `$HOME` directory from Claude, significantly reducing exposure of personal files, dotfiles, secrets, and caches.
@@ -161,7 +163,7 @@ Claude Code runs directly on the host system with full user privileges:
 - Use `--deny-path PATH` to hide a path entirely (appears empty/blocked inside the sandbox). In Docker/bubblewrap this is implemented with empty overlays; in Seatbelt it raises access errors.
 - `--add-dir PATH[:ro|:rw]` lets you control permissions inline when mounting additional content.
 - Claude Code's local `.claude/settings.local.json` can also contribute read/write mounts through its `additionalDirectories` array. `cco` treats those entries like local `--add-dir PATH:rw` rules and warns if the file exists but cannot be parsed.
-- Git worktree support auto-detects `git rev-parse --git-common-dir` only for trusted git layouts. Use `--disable-git-worktree-common-dir` if you want fully manual control and no auto-added git paths.
+- Git worktree support auto-detects `git rev-parse --git-common-dir` from the current directory and immediate child git checkouts, but only auto-allows trusted git layouts. Use `--disable-git-worktree-common-dir` if you want fully manual control and no auto-added git paths.
 
 ## Terminal Injection Attacks (Linux)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,8 +54,8 @@ Claude Code runs directly on the host system with full user privileges:
 - **Read/write reality**: Claude's config directories (`~/.claude`, detected config dir, `.claude.json`) are mounted read-write so it can persist preferences and session state.
 - **Credential file access**: The credentials JSON is mounted read-only by default, so Claude cannot update tokens unless `--allow-oauth-refresh` is explicitly enabled.
 - **No image persistence**: Credentials are never baked into the Docker image; temporary files are cleaned up after the session.
-- **Startup recovery helpers**: Before sandbox startup, `cco` may offer two host-side recovery steps when credentials are unusable: `security unlock-keychain ...` for locked macOS login keychains over SSH, and a one-shot plain `claude -p ...` call to refresh expired OAuth credentials when the chosen sandbox cannot safely sync the refresh back.
-- **Consent boundary**: Those startup recovery helpers run only after an interactive confirmation, or automatically when `--yes` / `-y` is supplied. They are additive host-side actions, but they do not grant Claude ongoing general Keychain access or silently widen the sandbox after startup.
+- **Startup credential maintenance**: Before sandbox startup, `cco` may run a one-shot plain `claude -p ...` call on the host when stored OAuth credentials expire soon and the chosen sandbox cannot safely sync an in-sandbox refresh back. It may also offer `security unlock-keychain ...` for locked macOS login keychains over SSH.
+- **Consent boundary**: Keychain unlock recovery still runs only after an interactive confirmation, or automatically when `--yes` / `-y` is supplied. The OAuth maintenance refresh is a fixed `cco`-controlled host action before sandbox startup; it does not grant Claude ongoing general Keychain access or widen the sandbox after startup.
 
 ## Threat Model
 
@@ -248,21 +248,23 @@ When enabled (Docker backend only), `cco`:
 - Preserves container credentials for manual recovery if sync-back fails
 - Only enables when explicitly requested via `--allow-oauth-refresh`
 
-### Startup Recovery Prompts (`--yes`)
-**Purpose**: Lets `cco` auto-accept startup recovery prompts such as unlocking the macOS login keychain over SSH or running a one-shot plain Claude OAuth refresh before entering the sandbox.
+### Startup Credential Maintenance
+**Purpose**: Lets `cco` keep Claude credentials usable before entering the sandbox without giving sandboxed Claude broader write access. When stored OAuth credentials expire soon and the selected backend cannot safely persist an in-sandbox refresh, `cco` runs one fixed plain-Claude refresh on the host. `--yes` still only controls interactive recovery prompts such as unlocking the macOS login keychain over SSH.
 
 **Security Implications**:
 - **Host-side command execution before sandboxing**: `cco` may run `security unlock-keychain ...` or a plain `claude -p ...` command on the host before the sandbox starts.
-- **Removes an interactive confirmation step**: `--yes` does not add new capabilities by itself, but it does make those recovery actions happen automatically when the preflight detects the relevant failure mode.
+- **Automatic OAuth maintenance**: The plain-Claude refresh can run without a prompt when expiry is near, so startup does not depend on granting sandboxed Claude home-directory or credential write access.
+- **Prompt auto-acceptance**: `--yes` does not add new capabilities by itself, but it does make prompt-based recovery actions happen automatically when the preflight detects the relevant failure mode.
 - **Plain-Claude refresh is outside `cco` isolation**: The OAuth recovery helper intentionally runs outside the sandbox so refreshed credentials can land back in the host's normal Claude auth store.
 
 **What this does NOT do**:
 - It does **not** grant Claude unrestricted Keychain access during the session. That still requires `--allow-keychain`, which is a much higher-risk mode.
-- It does **not** make host-side recovery actions available unless the preflight detects a locked keychain or an OAuth refresh problem.
+- It does **not** make host-side recovery actions available unless the preflight detects a locked keychain or an OAuth credential that expires soon.
+- It does **not** make real `$HOME` broadly writable in native Linux sandbox mode.
 
 **Recommendation**:
 - Treat `--yes` as a convenience flag for trusted, unattended startup only.
-- Prefer the default interactive confirmation if you want a deliberate checkpoint before any host-side recovery action runs.
+- Prefer the default interactive confirmation if you want a deliberate checkpoint before prompt-based host recovery actions run.
 
 ### Keychain Access (`--allow-keychain`)
 **Purpose**: Allows Claude to access macOS Keychain for OAuth token refresh in seatbelt sandbox mode.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,10 +52,10 @@ Claude Code runs directly on the host system with full user privileges:
 ### Credential Protection
 - **Runtime extraction**: Each session fetches fresh Claude credentials (macOS Keychain or Linux config file) into a temporary location.
 - **Read/write reality**: Claude's config directories (`~/.claude`, detected config dir, `.claude.json`) are mounted read-write so it can persist preferences and session state.
-- **Credential file access**: Docker uses a temporary credentials mount that is read-only by default and becomes read/write only with `--allow-oauth-refresh`. Native backends expose Claude's normal config paths for CLI compatibility, but `cco` treats backends that cannot safely persist an in-sandbox refresh as non-persisting and refreshes near-expiry OAuth credentials before startup instead.
+- **Credential file access**: Docker uses a temporary credentials mount that is read-only by default and becomes read/write only with `--allow-oauth-refresh`. Native backends expose Claude's normal config paths for CLI compatibility, but `cco` treats backends that cannot safely persist an in-sandbox refresh as non-persisting. For those backends, expired OAuth credentials are repaired before startup and valid near-expiry credentials are refreshed by a background host-side helper.
 - **No image persistence**: Credentials are never baked into the Docker image; temporary files are cleaned up after the session.
-- **Startup credential maintenance**: Before sandbox startup, `cco` may run a one-shot plain `claude -p ...` call on the host when stored OAuth credentials expire soon and the chosen sandbox cannot safely sync an in-sandbox refresh back. It may also offer `security unlock-keychain ...` for locked macOS login keychains over SSH.
-- **Consent boundary**: Keychain unlock recovery still runs only after an interactive confirmation, or automatically when `--yes` / `-y` is supplied. The OAuth maintenance refresh is a fixed `cco`-controlled host action before sandbox startup; it does not grant Claude ongoing general Keychain access or widen the sandbox after startup.
+- **Startup credential maintenance**: Before sandbox startup, `cco` may run a one-shot plain `claude -p ...` call on the host when stored OAuth credentials are already expired and the chosen sandbox cannot safely sync an in-sandbox refresh back. For valid credentials that expire within two hours, `cco` starts a lock-protected background host-side refresh and continues startup. It may also offer `security unlock-keychain ...` for locked macOS login keychains over SSH.
+- **Consent boundary**: Keychain unlock recovery still runs only after an interactive confirmation, or automatically when `--yes` / `-y` is supplied. OAuth maintenance is a fixed `cco`-controlled host action; it does not grant Claude ongoing general Keychain access or widen the sandbox after startup.
 
 ## Threat Model
 
@@ -251,17 +251,17 @@ When enabled (Docker backend only), `cco`:
 - Only enables when explicitly requested via `--allow-oauth-refresh`
 
 ### Startup Credential Maintenance
-**Purpose**: Lets `cco` keep Claude credentials usable before entering the sandbox without giving sandboxed Claude broader write access. When stored OAuth credentials expire soon and the selected backend cannot safely persist an in-sandbox refresh, `cco` runs one fixed plain-Claude refresh on the host. `--yes` still only controls interactive recovery prompts such as unlocking the macOS login keychain over SSH.
+**Purpose**: Lets `cco` keep Claude credentials usable without giving sandboxed Claude broader write access. When stored OAuth credentials are already expired and the selected backend cannot safely persist an in-sandbox refresh, `cco` runs one fixed plain-Claude refresh on the host before startup and verifies the credentials were repaired. When credentials are valid but expire within two hours, `cco` starts a lock-protected background host-side refresh and lets startup continue. `--yes` still only controls interactive recovery prompts such as unlocking the macOS login keychain over SSH.
 
 **Security Implications**:
-- **Host-side command execution before sandboxing**: `cco` may run `security unlock-keychain ...` or a plain `claude -p ...` command on the host before the sandbox starts.
-- **Automatic OAuth maintenance**: The plain-Claude refresh can run without a prompt when expiry is near, so startup does not depend on granting sandboxed Claude home-directory or credential write access.
+- **Host-side command execution around startup**: `cco` may run `security unlock-keychain ...` or a plain `claude -p ...` command on the host before the sandbox starts. The near-expiry OAuth helper can continue in the background after startup begins.
+- **Automatic OAuth maintenance**: The plain-Claude refresh can run without a prompt when credentials are expired or close to expiry, so startup does not depend on granting sandboxed Claude home-directory or credential write access.
 - **Prompt auto-acceptance**: `--yes` does not add new capabilities by itself, but it does make prompt-based recovery actions happen automatically when the preflight detects the relevant failure mode.
 - **Plain-Claude refresh is outside `cco` isolation**: The OAuth recovery helper intentionally runs outside the sandbox so refreshed credentials can land back in the host's normal Claude auth store.
 
 **What this does NOT do**:
 - It does **not** grant Claude unrestricted Keychain access during the session. That still requires `--allow-keychain`, which is a much higher-risk mode.
-- It does **not** make host-side recovery actions available unless the preflight detects a locked keychain or an OAuth credential that expires soon.
+- It does **not** make host-side recovery actions available unless the preflight detects a locked keychain, expired OAuth credentials, or OAuth credentials that expire within two hours.
 - It does **not** make real `$HOME` broadly writable in native Linux sandbox mode.
 
 **Recommendation**:

--- a/cco
+++ b/cco
@@ -913,6 +913,11 @@ ensure_accessible_macos_keychain_credentials() {
 }
 
 ensure_refreshable_oauth_credentials() {
+	# Token from environment is managed externally; nothing to refresh
+	if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+		return 0
+	fi
+
 	local credentials_payload expires_at_ms
 	credentials_payload=$(get_claude_credentials_payload)
 
@@ -966,6 +971,12 @@ ensure_refreshable_oauth_credentials() {
 # Verify Claude Code authentication is available
 verify_claude_authentication() {
 	log "Verifying Claude Code authentication..."
+
+	# If CLAUDE_CODE_OAUTH_TOKEN is set, Claude Code will use it directly
+	if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+		log "Using CLAUDE_CODE_OAUTH_TOKEN from environment"
+		return 0
+	fi
 
 	local claude_config_dir credentials_file
 	claude_config_dir=$(find_claude_config_dir)
@@ -1878,6 +1889,7 @@ run_container() {
 		# Anthropic / Claude Code
 		"ANTHROPIC_API_KEY"
 		"ANTHROPIC_BASE_URL"
+		"CLAUDE_CODE_OAUTH_TOKEN"
 		"CLAUDE_CONFIG_DIR"
 		# OpenAI / Codex
 		"OPENAI_API_KEY"
@@ -3051,6 +3063,7 @@ if [[ $# -gt 0 ]]; then
 		echo "                        Trust external git common dirs for worktree support"
 		echo "  CCO_SANDBOX_ARGS_FILE Persistent sandbox args file (one arg per line)"
 		echo "  ANTHROPIC_API_KEY     Passed through automatically"
+		echo "  CLAUDE_CODE_OAUTH_TOKEN  Passed through (skips credential file check)"
 		echo "  OPENAI_API_KEY        Passed through automatically"
 		echo "  GEMINI_API_KEY        Passed through automatically"
 		echo "  FACTORY_API_KEY       Passed through automatically"

--- a/cco
+++ b/cco
@@ -3185,38 +3185,45 @@ main() {
 	# If inside a git worktree, the object store lives in the main repo's
 	# .git directory, not the worktree. Add it as an additional dir so both
 	# sandbox backends whitelist it for writes automatically.
+	# Also check immediate subdirectories, since cco may be launched from a
+	# parent folder that contains git worktree checkouts.
 	if [[ "$enable_git_worktree_common_dir" == true ]] && command -v git &>/dev/null; then
-		local git_common_dir_raw git_dir_raw git_common_dir git_dir
-		git_common_dir_raw="$(git rev-parse --git-common-dir 2>/dev/null)" || true
-		git_dir_raw="$(git rev-parse --git-dir 2>/dev/null)" || true
+		local _cco_check_dirs=("$PWD")
+		# Scan immediate subdirs for git repos/worktrees via direct .git glob
+		for _cco_gitdir in "$PWD"/*/.git; do
+			[[ -e "$_cco_gitdir" ]] || continue
+			_cco_check_dirs+=("${_cco_gitdir%/.git}")
+		done
 
-		if [[ -n "$git_common_dir_raw" && -n "$git_dir_raw" ]]; then
-			if git_common_dir="$(resolve_existing_dir "$git_common_dir_raw")"; then
-				if git_dir="$(resolve_existing_dir "$git_dir_raw")"; then
-					local trusted_layout=false
-					if [[ "$git_dir" == "$git_common_dir" ]]; then
-						trusted_layout=true
-					elif [[ "$git_dir" == "$git_common_dir"/worktrees/* ]]; then
-						trusted_layout=true
-					fi
+		for _cco_check_dir in "${_cco_check_dirs[@]}"; do
+			local git_common_dir_raw git_dir_raw git_common_dir git_dir
+			git_common_dir_raw="$(git -C "$_cco_check_dir" rev-parse --git-common-dir 2>/dev/null)" || true
+			git_dir_raw="$(git -C "$_cco_check_dir" rev-parse --git-dir 2>/dev/null)" || true
 
-					if [[ "$trusted_layout" == true || "$allow_external_git_dir" == true ]]; then
-						if [[ "$git_common_dir" != "$PWD"/.git ]] && ! path_in_array "$git_common_dir" "${additional_dirs[@]}"; then
-							additional_dirs+=("$git_common_dir")
-							git_worktree_common_dir="$git_common_dir"
-							log "Adding git common dir for worktree support: $git_common_dir"
+			if [[ -n "$git_common_dir_raw" && -n "$git_dir_raw" ]]; then
+				if git_common_dir="$(resolve_existing_dir "$git_common_dir_raw")"; then
+					if git_dir="$(resolve_existing_dir "$git_dir_raw")"; then
+						local trusted_layout=false
+						if [[ "$git_dir" == "$git_common_dir" ]]; then
+							trusted_layout=true
+						elif [[ "$git_dir" == "$git_common_dir"/worktrees/* ]]; then
+							trusted_layout=true
 						fi
-					else
-						warn "Skipping untrusted git common dir layout: $git_common_dir"
-						warn "Use --allow-external-git-dir (or CCO_ALLOW_EXTERNAL_GIT_DIR=1) to allow it"
+
+						if [[ "$trusted_layout" == true || "$allow_external_git_dir" == true ]]; then
+							if [[ "$git_common_dir" != "$PWD"/.git ]] && ! path_in_array "$git_common_dir" "${additional_dirs[@]}"; then
+								additional_dirs+=("$git_common_dir")
+								git_worktree_common_dir="$git_common_dir"
+								log "Adding git common dir for worktree support: $git_common_dir"
+							fi
+						else
+							warn "Skipping untrusted git common dir layout: $git_common_dir"
+							warn "Use --allow-external-git-dir (or CCO_ALLOW_EXTERNAL_GIT_DIR=1) to allow it"
+						fi
 					fi
-				else
-					warn "Skipping git common dir: unable to resolve git dir path: $git_dir_raw"
 				fi
-			else
-				warn "Skipping git common dir: unable to resolve path: $git_common_dir_raw"
 			fi
-		fi
+		done
 	elif [[ "$enable_git_worktree_common_dir" == false ]]; then
 		log "Git worktree common-dir auto-detection disabled by flag"
 	fi

--- a/cco
+++ b/cco
@@ -1588,8 +1588,10 @@ run_native_sandbox() {
 	# Load .env file first (matching Docker backend behavior)
 	if [[ -f ".env" ]]; then
 		while IFS= read -r line || [[ -n "$line" ]]; do
-			# Skip empty lines and comments
-			[[ -z "$line" || "$line" == \#* ]] && continue
+			# Match Docker-style comment handling by ignoring leading whitespace.
+			local trimmed_line="${line#"${line%%[![:space:]]*}"}"
+			[[ -z "$trimmed_line" || "$trimmed_line" == \#* ]] && continue
+			[[ "$trimmed_line" != *"="* ]] && continue
 			local env_key="${line%%=*}"
 			local env_val="${line#*=}"
 			export "${env_key}=${env_val}"

--- a/cco
+++ b/cco
@@ -820,7 +820,7 @@ run_unsandboxed_claude_refresh() {
 	read -ra claude_cmd <<<"$claude_cmd_str"
 	refresh_dir=$(mktemp -d)
 
-	log "Running a one-shot unsandboxed Claude call to refresh OAuth credentials..."
+	log "Refreshing Claude OAuth credentials before starting sandbox; this may take a moment..."
 	(
 		cd "$refresh_dir" || exit 1
 		"${claude_cmd[@]}" -p --output-format text --no-session-persistence "Reply with OK and nothing else."

--- a/cco
+++ b/cco
@@ -145,15 +145,34 @@ persist_scope_slug_for_root() {
 	fi
 }
 
+probe_linux_bwrap() {
+	bwrap --ro-bind / / true
+}
+
+explain_linux_bwrap_failure() {
+	local probe_output="$1"
+	warn "Native Linux sandbox is unavailable: bubblewrap is installed but cannot start."
+	if [[ "$probe_output" == *"setting up uid map"* && "$probe_output" == *"Permission denied"* ]]; then
+		warn "bubblewrap could not set up its uid_map; AppArmor/user-namespace policy is preventing setup."
+	elif [[ -n "$probe_output" ]]; then
+		local first_line="${probe_output%%$'\n'*}"
+		warn "bubblewrap probe failed: $first_line"
+	fi
+}
+
 # Detect available sandbox backends
 detect_sandbox_backend() {
 	local force_backend="$1"
+	local forced_native=false
 
 	if [[ -n "$force_backend" ]]; then
 		case "$force_backend" in
-		native | docker)
-			SANDBOX_BACKEND="$force_backend"
+		docker)
+			SANDBOX_BACKEND="docker"
 			return
+			;;
+		native)
+			forced_native=true
 			;;
 		auto | "")
 			# Continue with auto-detection
@@ -175,6 +194,9 @@ detect_sandbox_backend() {
 		if command -v sandbox-exec &>/dev/null; then
 			SANDBOX_BACKEND="native"
 			log "Using native sandbox (Seatbelt)"
+		elif [[ "$forced_native" == true ]]; then
+			error "Native sandbox was requested with --backend native, but sandbox-exec is not available."
+			exit 1
 		elif command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
 			SANDBOX_BACKEND="docker"
 			log "Using Docker sandbox (Seatbelt not available)"
@@ -185,12 +207,35 @@ detect_sandbox_backend() {
 	elif [[ "$os" == "Linux" ]]; then
 		# Linux: Check for bubblewrap
 		if command -v bwrap &>/dev/null; then
-			SANDBOX_BACKEND="native"
-			log "Using native sandbox (bubblewrap)"
+			local bwrap_probe_output
+			if bwrap_probe_output=$(probe_linux_bwrap 2>&1); then
+				SANDBOX_BACKEND="native"
+				log "Using native sandbox (bubblewrap)"
+			else
+				explain_linux_bwrap_failure "$bwrap_probe_output"
+				if [[ "$forced_native" == true ]]; then
+					error "Native sandbox was requested with --backend native, so cco cannot fall back automatically."
+					exit 1
+				elif command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
+					SANDBOX_BACKEND="docker"
+					log "Using Docker sandbox (bubblewrap blocked by host policy)"
+				else
+					error "No sandbox backend available. Install Docker or fix the host bubblewrap/AppArmor policy."
+					exit 1
+				fi
+			fi
 		elif command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
+			if [[ "$forced_native" == true ]]; then
+				error "Native sandbox was requested with --backend native, but bubblewrap is not installed."
+				exit 1
+			fi
 			SANDBOX_BACKEND="docker"
 			log "Using Docker sandbox (bubblewrap not available)"
 		else
+			if [[ "$forced_native" == true ]]; then
+				error "Native sandbox was requested with --backend native, but bubblewrap is not installed."
+				exit 1
+			fi
 			error "No sandbox backend available. Install bubblewrap or Docker."
 			exit 1
 		fi

--- a/cco
+++ b/cco
@@ -727,6 +727,15 @@ oauth_token_needs_startup_refresh() {
 	((expires_at_ms <= now_ms + refresh_window_ms))
 }
 
+oauth_token_needs_preemptive_startup_refresh() {
+	local expires_at_ms="$1"
+	local now_ms refresh_window_ms
+	now_ms=$(($(date +%s) * 1000))
+	refresh_window_ms=$((12 * 60 * 60 * 1000))
+
+	((expires_at_ms <= now_ms + refresh_window_ms))
+}
+
 backend_can_persist_oauth_refresh() {
 	if command -v security &>/dev/null; then
 		if [[ "$SANDBOX_BACKEND" == "native" ]]; then
@@ -743,7 +752,7 @@ backend_can_persist_oauth_refresh() {
 	fi
 
 	if [[ "$SANDBOX_BACKEND" == "native" ]]; then
-		return 0
+		return 1
 	fi
 
 	if [[ "$SANDBOX_BACKEND" == "docker" && "$allow_oauth_refresh" == true ]]; then
@@ -929,43 +938,35 @@ ensure_refreshable_oauth_credentials() {
 		return 0
 	fi
 
-	if ! oauth_token_needs_startup_refresh "$expires_at_ms"; then
-		return 0
-	fi
-
 	if backend_can_persist_oauth_refresh; then
-		warn "Claude OAuth token is expired or near expiry, but this backend can persist a refresh"
+		if oauth_token_needs_startup_refresh "$expires_at_ms"; then
+			warn "Claude OAuth token is expired or near expiry, but this backend can persist a refresh"
+		fi
 		return 0
 	fi
 
-	warn "Claude OAuth token is expired or near expiry"
-	warn "This sandbox path cannot safely persist Claude's refresh back to the host credentials"
+	if ! oauth_token_needs_preemptive_startup_refresh "$expires_at_ms"; then
+		return 0
+	fi
 
-	if confirm_default_yes \
-		"cco thinks Claude's OAuth token needs a refresh, and this sandbox cannot save the refreshed credentials back to your host. Run a one-shot plain Claude refresh now before starting cco?" \
-		"--yes enabled; refreshing Claude OAuth credentials before starting cco"; then
-		if ! run_unsandboxed_claude_refresh; then
-			error "Claude refresh did not complete successfully"
-			error "Run plain \`$(get_claude_command)\` once outside the sandbox, then retry cco."
+	log "Claude OAuth token expires soon; refreshing once before sandbox startup"
+
+	if ! run_unsandboxed_claude_refresh; then
+		error "Claude refresh did not complete successfully"
+		error "Run plain \`$(get_claude_command)\` once outside the sandbox, then retry cco."
+		exit 1
+	fi
+
+	credentials_payload=$(get_claude_credentials_payload)
+	if [[ -n "$credentials_payload" ]] && expires_at_ms=$(extract_oauth_expiry_ms "$credentials_payload"); then
+		if oauth_token_needs_startup_refresh "$expires_at_ms"; then
+			error "Claude credentials still look expired after the refresh attempt"
+			error "Run plain \`$(get_claude_command)\` outside the sandbox, finish any login flow, then retry cco."
 			exit 1
 		fi
-
-		credentials_payload=$(get_claude_credentials_payload)
-		if [[ -n "$credentials_payload" ]] && expires_at_ms=$(extract_oauth_expiry_ms "$credentials_payload"); then
-			if oauth_token_needs_startup_refresh "$expires_at_ms"; then
-				error "Claude credentials still look expired after the refresh attempt"
-				error "Run plain \`$(get_claude_command)\` outside the sandbox, finish any login flow, then retry cco."
-				exit 1
-			fi
-		fi
-
-		log "Claude OAuth credentials refreshed"
-		return 0
 	fi
 
-	error "Claude credentials need an out-of-sandbox refresh before this cco session can start"
-	error "Run plain \`$(get_claude_command)\` once outside the sandbox, then retry cco."
-	exit 1
+	log "Claude OAuth credentials refreshed"
 }
 
 # Verify Claude Code authentication is available

--- a/cco
+++ b/cco
@@ -772,13 +772,28 @@ oauth_token_needs_startup_refresh() {
 	((expires_at_ms <= now_ms + refresh_window_ms))
 }
 
-oauth_token_needs_preemptive_startup_refresh() {
+oauth_token_is_expired() {
+	local expires_at_ms="$1"
+	local now_ms
+	now_ms=$(($(date +%s) * 1000))
+
+	((expires_at_ms <= now_ms))
+}
+
+oauth_token_needs_background_refresh() {
 	local expires_at_ms="$1"
 	local now_ms refresh_window_ms
 	now_ms=$(($(date +%s) * 1000))
-	refresh_window_ms=$((12 * 60 * 60 * 1000))
+	refresh_window_ms=$((2 * 60 * 60 * 1000))
 
 	((expires_at_ms <= now_ms + refresh_window_ms))
+}
+
+oauth_background_refresh_lock_dir() {
+	local marker_key marker_hash
+	marker_key="$(get_claude_config_dir):$SANDBOX_BACKEND"
+	marker_hash=$(sha256_prefix8 "$marker_key") || return 1
+	printf '%s/cco/oauth-refresh-%s.lock\n' "${XDG_CACHE_HOME:-$HOME/.cache}" "$marker_hash"
 }
 
 backend_can_persist_oauth_refresh() {
@@ -829,6 +844,23 @@ run_unsandboxed_claude_refresh() {
 
 	rm -rf "$refresh_dir"
 	return "$status"
+}
+
+start_background_claude_refresh() {
+	local lock_dir
+	lock_dir=$(oauth_background_refresh_lock_dir) || return 0
+	mkdir -p "$(dirname "$lock_dir")" 2>/dev/null || return 0
+
+	if ! mkdir "$lock_dir" 2>/dev/null; then
+		log "Claude OAuth credential refresh is already running in the background"
+		return 0
+	fi
+
+	log "Refreshing Claude OAuth credentials in the background before they expire..."
+	(
+		trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
+		run_unsandboxed_claude_refresh >/dev/null 2>&1 || true
+	) &
 }
 
 confirm_default_yes() {
@@ -990,32 +1022,33 @@ ensure_refreshable_oauth_credentials() {
 		return 0
 	fi
 
-	if ! oauth_token_needs_preemptive_startup_refresh "$expires_at_ms"; then
+	if oauth_token_is_expired "$expires_at_ms"; then
+		if ! run_unsandboxed_claude_refresh; then
+			error "Claude OAuth refresh did not complete"
+			error "Run plain \`$(get_claude_command)\` to re-authenticate, then retry cco."
+			exit 1
+		fi
+
+		credentials_payload=$(get_claude_credentials_payload)
+		if [[ -z "$credentials_payload" ]] || ! expires_at_ms=$(extract_oauth_expiry_ms "$credentials_payload"); then
+			error "Could not verify Claude OAuth credentials after the refresh attempt"
+			error "Run plain \`$(get_claude_command)\` to re-authenticate, then retry cco."
+			exit 1
+		fi
+
+		if oauth_token_is_expired "$expires_at_ms"; then
+			error "Claude OAuth credentials are still expired after the refresh attempt"
+			error "Run plain \`$(get_claude_command)\` to re-authenticate, then retry cco."
+			exit 1
+		fi
+
+		log "Claude OAuth credentials refreshed"
 		return 0
 	fi
 
-	log "Claude OAuth token expires soon; refreshing once before sandbox startup"
-
-	if ! run_unsandboxed_claude_refresh; then
-		if ! oauth_token_needs_startup_refresh "$expires_at_ms"; then
-			warn "Claude OAuth pre-start refresh did not complete; continuing because credentials are still valid"
-			return 0
-		fi
-		error "Claude refresh did not complete successfully"
-		error "Run plain \`$(get_claude_command)\` once outside the sandbox, then retry cco."
-		exit 1
+	if oauth_token_needs_background_refresh "$expires_at_ms"; then
+		start_background_claude_refresh
 	fi
-
-	credentials_payload=$(get_claude_credentials_payload)
-	if [[ -n "$credentials_payload" ]] && expires_at_ms=$(extract_oauth_expiry_ms "$credentials_payload"); then
-		if oauth_token_needs_startup_refresh "$expires_at_ms"; then
-			error "Claude credentials still look expired after the refresh attempt"
-			error "Run plain \`$(get_claude_command)\` outside the sandbox, finish any login flow, then retry cco."
-			exit 1
-		fi
-	fi
-
-	log "Claude OAuth credentials refreshed"
 }
 
 # Verify Claude Code authentication is available

--- a/cco
+++ b/cco
@@ -952,6 +952,10 @@ ensure_refreshable_oauth_credentials() {
 	log "Claude OAuth token expires soon; refreshing once before sandbox startup"
 
 	if ! run_unsandboxed_claude_refresh; then
+		if ! oauth_token_needs_startup_refresh "$expires_at_ms"; then
+			warn "Claude OAuth pre-start refresh did not complete; continuing because credentials are still valid"
+			return 0
+		fi
 		error "Claude refresh did not complete successfully"
 		error "Run plain \`$(get_claude_command)\` once outside the sandbox, then retry cco."
 		exit 1

--- a/sandbox
+++ b/sandbox
@@ -206,30 +206,6 @@ run_linux() {
 		[[ -e "$p" ]] && args+=(--ro-bind "$p" "$p")
 	done
 
-	# 2b) Allow new file creation in $HOME for Claude's lock dirs and
-	# atomic-write temp files, while keeping existing entries read-only
-	# unless they already overlap an explicit writable path.
-	args+=(--bind "$HOME" "$HOME")
-	for item in "$HOME"/.* "$HOME"/*; do
-		[[ "$item" == "$HOME/." || "$item" == "$HOME/.." ]] && continue
-		[[ -L "$item" || ! -e "$item" ]] && continue
-
-		local item_is_writable=false
-		if [[ "$item" == "$PWD_ABS" || "$PWD_ABS" == "$item"/* || "$item" == "$PWD_ABS"/* ]]; then
-			item_is_writable=true
-		else
-			for wp in "${write_paths[@]+"${write_paths[@]}"}"; do
-				if [[ "$item" == "$wp" || "$wp" == "$item"/* || "$item" == "$wp"/* ]]; then
-					item_is_writable=true
-					break
-				fi
-			done
-		fi
-
-		[[ "$item_is_writable" == true ]] && continue
-		args+=(--ro-bind "$item" "$item")
-	done
-
 	# 3) If safe mode enabled, hide the rest of $HOME by default.
 	if [[ "$safe_mode" == true ]]; then
 		args+=(--tmpfs "$HOME")

--- a/sandbox
+++ b/sandbox
@@ -206,6 +206,30 @@ run_linux() {
 		[[ -e "$p" ]] && args+=(--ro-bind "$p" "$p")
 	done
 
+	# 2b) Allow new file creation in $HOME for Claude's lock dirs and
+	# atomic-write temp files, while keeping existing entries read-only
+	# unless they already overlap an explicit writable path.
+	args+=(--bind "$HOME" "$HOME")
+	for item in "$HOME"/.* "$HOME"/*; do
+		[[ "$item" == "$HOME/." || "$item" == "$HOME/.." ]] && continue
+		[[ -L "$item" || ! -e "$item" ]] && continue
+
+		local item_is_writable=false
+		if [[ "$item" == "$PWD_ABS" || "$PWD_ABS" == "$item"/* || "$item" == "$PWD_ABS"/* ]]; then
+			item_is_writable=true
+		else
+			for wp in "${write_paths[@]+"${write_paths[@]}"}"; do
+				if [[ "$item" == "$wp" || "$wp" == "$item"/* || "$item" == "$wp"/* ]]; then
+					item_is_writable=true
+					break
+				fi
+			done
+		fi
+
+		[[ "$item_is_writable" == true ]] && continue
+		args+=(--ro-bind "$item" "$item")
+	done
+
 	# 3) If safe mode enabled, hide the rest of $HOME by default.
 	if [[ "$safe_mode" == true ]]; then
 		args+=(--tmpfs "$HOME")
@@ -628,7 +652,13 @@ run_macos() {
 		printf '(allow file-write* (subpath "%s/Library/Logs"))\n' "$(policy_quote "$HOME")"
 		printf '(allow file-write* (subpath "%s/Library/Application Support"))\n' "$(policy_quote "$HOME")"
 
-		# 6. Keychain access for OAuth token refresh (only if explicitly allowed)
+		# 6. Claude lock dirs and atomic-write temp files in $HOME
+		printf '(allow file-write* (regex #"^%s/\\.claude\\.lock$"))\n' "$(policy_quote "$HOME")"
+		printf '(allow file-write* (regex #"^%s/\\.claude\\.lock/"))\n' "$(policy_quote "$HOME")"
+		printf '(allow file-write* (regex #"^%s/\\.claude\\.json\\.lock"))\n' "$(policy_quote "$HOME")"
+		printf '(allow file-write* (regex #"^%s/\\.claude\\.json\\.tmp\\."))\n' "$(policy_quote "$HOME")"
+
+		# 7. Keychain access for OAuth token refresh (only if explicitly allowed)
 		if [[ "$allow_keychain" == true ]]; then
 			printf '(allow file-read* (subpath "%s/Library/Keychains"))\n' "$(policy_quote "$HOME")"
 			printf '(allow file-read* (subpath "/Library/Keychains"))\n'

--- a/tests/test_env_flag.sh
+++ b/tests/test_env_flag.sh
@@ -114,6 +114,19 @@ else
 	fail ".env file skips comments and blank lines: got '$output'"
 fi
 
+echo "Test: .env file skips indented comments"
+cat >"$TEST_DIR/.env" <<'EOF'
+FIRST_VAR=one
+ # Indented comment
+SECOND_VAR=two
+EOF
+# shellcheck disable=SC2016
+if output=$(cd "$TEST_DIR" && "$OLDPWD/cco" shell 'echo ${FIRST_VAR}_${SECOND_VAR}') && [[ "$output" == "one_two" ]]; then
+	pass ".env file skips indented comments"
+else
+	fail ".env file skips indented comments: got '$output'"
+fi
+
 echo "Test: -e flag takes precedence over .env file"
 echo 'OVERRIDE_VAR=from_dotenv' >"$TEST_DIR/.env"
 # shellcheck disable=SC2016

--- a/tests/test_git_worktree_support.sh
+++ b/tests/test_git_worktree_support.sh
@@ -140,6 +140,19 @@ for backend in native docker; do
 			"docker mounts trusted git common dir without remap"
 	fi
 
+	run_backend_case "$backend" "parent-launched worktree" "$TEST_ROOT" "$TEST_HOME" "$TEST_ROOT/parent_${backend}.log"
+	assert_contains "$TEST_ROOT/parent_${backend}.log" \
+		"Adding git common dir for worktree support: $MAIN_GIT_DIR" \
+		"parent launch adds main git dir for nested worktree ($backend)"
+	assert_not_contains "$TEST_ROOT/parent_${backend}.log" \
+		"Skipping untrusted git common dir layout" \
+		"parent launch keeps trusted worktree layout ($backend)"
+	if [[ "$backend" == "docker" ]]; then
+		assert_contains "$TEST_ROOT/parent_${backend}.log" \
+			"Mounting additional directory: $MAIN_GIT_DIR" \
+			"docker mounts nested worktree git common dir from parent launch"
+	fi
+
 	run_backend_case "$backend" "trusted worktree with auto-detect disabled" "$WORKTREE_DIR" "$TEST_HOME" "$TEST_ROOT/disabled_${backend}.log" \
 		--disable-git-worktree-common-dir
 	assert_contains "$TEST_ROOT/disabled_${backend}.log" \

--- a/tests/test_sandbox.sh
+++ b/tests/test_sandbox.sh
@@ -131,6 +131,37 @@ else
 fi
 
 #
+# Claude OAuth persistence path tests (issue #48)
+#
+
+echo ""
+echo "--- Claude OAuth Persistence Paths (issue #48) ---"
+
+CLAUDE_HOME="$HOME/.sandbox_claude_home_$$"
+mkdir -p "$CLAUDE_HOME/existing-dir"
+echo "original" >"$CLAUDE_HOME/existing-dir/existing.txt"
+
+echo "Test: Claude lock and temp paths under HOME are writable"
+if HOME="$CLAUDE_HOME" ./sandbox sh -c 'mkdir "$HOME/.claude.lock" && rmdir "$HOME/.claude.lock" && : >"$HOME/.claude.json.lock" && rm -f "$HOME/.claude.json.lock" && : >"$HOME/.claude.json.tmp.$$" && rm -f "$HOME/.claude.json.tmp.$$"' 2>/dev/null; then
+	pass "Claude lock and temp paths under HOME are writable"
+else
+	fail "Claude lock and temp paths under HOME are writable"
+fi
+
+echo "Test: Existing HOME entries stay read-only"
+if HOME="$CLAUDE_HOME" ./sandbox sh -c 'echo changed >"$HOME/existing-dir/existing.txt"' 2>/dev/null; then
+	fail "Existing HOME entries stay read-only"
+else
+	if [[ "$(cat "$CLAUDE_HOME/existing-dir/existing.txt")" == "original" ]]; then
+		pass "Existing HOME entries stay read-only"
+	else
+		fail "Existing HOME entries stay read-only: content changed"
+	fi
+fi
+
+rm -rf "$CLAUDE_HOME"
+
+#
 # Read-only path tests
 #
 

--- a/tests/test_sandbox.sh
+++ b/tests/test_sandbox.sh
@@ -130,22 +130,18 @@ else
 	fail "-w flag allows writes to specified file"
 fi
 
-#
-# Claude OAuth persistence path tests (issue #48)
-#
-
 echo ""
-echo "--- Claude OAuth Persistence Paths (issue #48) ---"
+echo "--- HOME Write Restrictions ---"
 
 CLAUDE_HOME="$HOME/.sandbox_claude_home_$$"
 mkdir -p "$CLAUDE_HOME/existing-dir"
 echo "original" >"$CLAUDE_HOME/existing-dir/existing.txt"
 
-echo "Test: Claude lock and temp paths under HOME are writable"
-if HOME="$CLAUDE_HOME" ./sandbox sh -c 'mkdir "$HOME/.claude.lock" && rmdir "$HOME/.claude.lock" && : >"$HOME/.claude.json.lock" && rm -f "$HOME/.claude.json.lock" && : >"$HOME/.claude.json.tmp.$$" && rm -f "$HOME/.claude.json.tmp.$$"' 2>/dev/null; then
-	pass "Claude lock and temp paths under HOME are writable"
+echo "Test: Arbitrary HOME sibling creation is blocked"
+if HOME="$CLAUDE_HOME" ./sandbox sh -c ': >"$HOME/.unexpected-home-write-$$"' 2>/dev/null; then
+	fail "Arbitrary HOME sibling creation is blocked"
 else
-	fail "Claude lock and temp paths under HOME are writable"
+	pass "Arbitrary HOME sibling creation is blocked"
 fi
 
 echo "Test: Existing HOME entries stay read-only"

--- a/tests/test_startup_preflights.sh
+++ b/tests/test_startup_preflights.sh
@@ -119,15 +119,16 @@ else
 fi
 
 echo ""
-echo "Test: OAuth preflight auto-refreshes when --yes is active"
+echo "Test: OAuth preflight refreshes automatically inside preemptive window"
 if (
 	PATH="$FAKE_BIN:$PATH"
 	source "$FUNCTIONS_ONLY"
-	yes_flag=true
+	yes_flag=false
 	allow_keychain=false
 	SANDBOX_BACKEND="native"
-	payload_file="$TEST_ROOT/oauth_payload.json"
-	printf '{"expiresAt":1}\n' >"$payload_file"
+	payload_file="$TEST_ROOT/oauth_preemptive_payload.json"
+	expires_at=$((($(date +%s) + (11 * 60 * 60)) * 1000))
+	printf '{"expiresAt":%s}\n' "$expires_at" >"$payload_file"
 	get_claude_credentials_payload() {
 		cat "$payload_file"
 	}
@@ -138,9 +139,84 @@ if (
 	ensure_refreshable_oauth_credentials
 	[[ "$(cat "$payload_file")" == '{"expiresAt":4102444800000}' ]]
 ); then
-	pass "OAuth preflight auto-refreshes with --yes"
+	pass "OAuth preflight refreshes automatically inside preemptive window"
 else
-	fail "OAuth preflight auto-refreshes with --yes"
+	fail "OAuth preflight refreshes automatically inside preemptive window"
+fi
+
+echo ""
+echo "Test: OAuth preflight accepts still-valid credentials after no-op refresh"
+if (
+	PATH="$FAKE_BIN:$PATH"
+	source "$FUNCTIONS_ONLY"
+	yes_flag=false
+	allow_keychain=false
+	SANDBOX_BACKEND="native"
+	refresh_attempts=0
+	expires_at=$((($(date +%s) + (11 * 60 * 60)) * 1000))
+	get_claude_credentials_payload() {
+		printf '{"expiresAt":%s}\n' "$expires_at"
+	}
+	run_unsandboxed_claude_refresh() {
+		refresh_attempts=$((refresh_attempts + 1))
+		return 0
+	}
+	ensure_refreshable_oauth_credentials
+	[[ "$refresh_attempts" -eq 1 ]]
+); then
+	pass "OAuth preflight accepts still-valid credentials after no-op refresh"
+else
+	fail "OAuth preflight accepts still-valid credentials after no-op refresh"
+fi
+
+echo ""
+echo "Test: OAuth preflight continues after failed preemptive refresh with valid token"
+if (
+	PATH="$FAKE_BIN:$PATH"
+	source "$FUNCTIONS_ONLY"
+	yes_flag=false
+	allow_keychain=false
+	SANDBOX_BACKEND="native"
+	refresh_attempts=0
+	expires_at=$((($(date +%s) + (11 * 60 * 60)) * 1000))
+	get_claude_credentials_payload() {
+		printf '{"expiresAt":%s}\n' "$expires_at"
+	}
+	run_unsandboxed_claude_refresh() {
+		refresh_attempts=$((refresh_attempts + 1))
+		return 1
+	}
+	ensure_refreshable_oauth_credentials
+	[[ "$refresh_attempts" -eq 1 ]]
+); then
+	pass "OAuth preflight continues after failed preemptive refresh with valid token"
+else
+	fail "OAuth preflight continues after failed preemptive refresh with valid token"
+fi
+
+echo ""
+echo "Test: OAuth preflight skips refresh outside preemptive window"
+if (
+	PATH="$FAKE_BIN:$PATH"
+	source "$FUNCTIONS_ONLY"
+	yes_flag=false
+	allow_keychain=false
+	SANDBOX_BACKEND="native"
+	refresh_attempts=0
+	expires_at=$((($(date +%s) + (13 * 60 * 60)) * 1000))
+	get_claude_credentials_payload() {
+		printf '{"expiresAt":%s}\n' "$expires_at"
+	}
+	run_unsandboxed_claude_refresh() {
+		refresh_attempts=$((refresh_attempts + 1))
+		return 0
+	}
+	ensure_refreshable_oauth_credentials
+	[[ "$refresh_attempts" -eq 0 ]]
+); then
+	pass "OAuth preflight skips refresh outside preemptive window"
+else
+	fail "OAuth preflight skips refresh outside preemptive window"
 fi
 
 echo ""

--- a/tests/test_startup_preflights.sh
+++ b/tests/test_startup_preflights.sh
@@ -12,6 +12,7 @@ CCO_BIN="$PWD/cco"
 
 PASSED=0
 FAILED=0
+SKIPPED=0
 
 pass() {
 	echo "PASS: $1"
@@ -21,6 +22,11 @@ pass() {
 fail() {
 	echo "FAIL: $1"
 	FAILED=$((FAILED + 1))
+}
+
+skip() {
+	echo "SKIP: $1"
+	SKIPPED=$((SKIPPED + 1))
 }
 
 assert_contains() {
@@ -35,6 +41,10 @@ assert_contains() {
 		printf '%s\n' "$haystack" | sed 's/^/    /'
 		fail "$name"
 	fi
+}
+
+supports_docker() {
+	command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
 }
 
 echo "=== Startup Preflight Regression Tests ==="
@@ -63,6 +73,7 @@ chmod +x "$FAKE_BIN/security"
 echo "Test: --help documents --yes"
 if output=$("$CCO_BIN" --help 2>&1); then
 	assert_contains "$output" "--yes, -y             Auto-accept startup recovery prompts" "--help shows --yes flag"
+	assert_contains "$output" "CLAUDE_CODE_OAUTH_TOKEN" "--help documents external Claude token"
 else
 	echo "  output:"
 	printf '%s\n' "$output" | sed 's/^/    /'
@@ -133,6 +144,25 @@ else
 fi
 
 echo ""
+echo "Test: OAuth preflight skips refresh when CLAUDE_CODE_OAUTH_TOKEN is set"
+if (
+	PATH="$FAKE_BIN:$PATH"
+	source "$FUNCTIONS_ONLY"
+	export CLAUDE_CODE_OAUTH_TOKEN="test-token"
+	payload_reads=0
+	get_claude_credentials_payload() {
+		payload_reads=$((payload_reads + 1))
+		return 0
+	}
+	ensure_refreshable_oauth_credentials
+	[[ "$payload_reads" -eq 0 ]]
+); then
+	pass "OAuth preflight skips refresh when external token is provided"
+else
+	fail "OAuth preflight skips refresh when external token is provided"
+fi
+
+echo ""
 echo "Test: OAuth expiry extraction prefers claudeAiOauth over mcpOAuth entries"
 if (
 	PATH="$FAKE_BIN:$PATH"
@@ -181,6 +211,30 @@ if (
 	pass "macOS SSH keychain recovery auto-unlocks with --yes"
 else
 	fail "macOS SSH keychain recovery auto-unlocks with --yes"
+fi
+
+echo ""
+echo "Test: auth file checks are skipped when CLAUDE_CODE_OAUTH_TOKEN is set"
+if (
+	PATH="$FAKE_BIN:$PATH"
+	source "$FUNCTIONS_ONLY"
+	export CLAUDE_CODE_OAUTH_TOKEN="test-token"
+	export HOME="$TEST_ROOT/external-token-home"
+	unset CLAUDE_CONFIG_DIR
+	keychain_attempts=0
+	find_claude_config_dir() {
+		printf '%s\n' "$TEST_ROOT/missing-claude-config"
+	}
+	capture_macos_keychain_credentials() {
+		keychain_attempts=$((keychain_attempts + 1))
+		return 1
+	}
+	verify_claude_authentication
+	[[ "$keychain_attempts" -eq 0 ]]
+); then
+	pass "auth file checks are skipped when external token is provided"
+else
+	fail "auth file checks are skipped when external token is provided"
 fi
 
 echo ""
@@ -266,9 +320,31 @@ else
 fi
 
 echo ""
+echo "Test: docker backend receives CLAUDE_CODE_OAUTH_TOKEN from host environment"
+if ! supports_docker; then
+	skip "docker backend unavailable for external-token passthrough"
+elif output=$(
+	HOME="$TEST_ROOT/docker-home" CLAUDE_CODE_OAUTH_TOKEN="test-token" \
+		"$CCO_BIN" --backend docker shell 'printf %s "$CLAUDE_CODE_OAUTH_TOKEN"' 2>&1
+); then
+	if [[ "$(printf '%s\n' "$output" | tail -n 1)" == "test-token" ]]; then
+		pass "docker backend receives external Claude token"
+	else
+		echo "  output:"
+		printf '%s\n' "$output" | sed 's/^/    /'
+		fail "docker backend receives external Claude token"
+	fi
+else
+	echo "  output:"
+	printf '%s\n' "$output" | sed 's/^/    /'
+	fail "docker backend receives external Claude token"
+fi
+
+echo ""
 echo "=== Results ==="
 echo "Passed:  $PASSED"
 echo "Failed:  $FAILED"
+echo "Skipped: $SKIPPED"
 
 if [[ $FAILED -gt 0 ]]; then
 	exit 1

--- a/tests/test_startup_preflights.sh
+++ b/tests/test_startup_preflights.sh
@@ -119,6 +119,34 @@ else
 fi
 
 echo ""
+echo "Test: non-Claude modes skip Claude authentication preflight"
+if (
+	source "$FUNCTIONS_ONLY"
+	command_flag=""
+	CCO_COMMAND=""
+	shell_mode=false
+	needs_claude_authentication
+
+	shell_mode=true
+	! needs_claude_authentication
+	shell_mode=false
+
+	command_flag="codex"
+	! needs_claude_authentication
+	command_flag="opencode"
+	! needs_claude_authentication
+	command_flag=""
+
+	CCO_COMMAND="custom-tool"
+	! needs_claude_authentication
+	unset CCO_COMMAND
+); then
+	pass "non-Claude modes skip Claude authentication preflight"
+else
+	fail "non-Claude modes skip Claude authentication preflight"
+fi
+
+echo ""
 echo "Test: OAuth preflight refreshes automatically inside preemptive window"
 if (
 	PATH="$FAKE_BIN:$PATH"

--- a/tests/test_startup_preflights.sh
+++ b/tests/test_startup_preflights.sh
@@ -147,104 +147,149 @@ else
 fi
 
 echo ""
-echo "Test: OAuth preflight refreshes automatically inside preemptive window"
+echo "Test: OAuth preflight repairs expired credentials before startup"
 if (
 	PATH="$FAKE_BIN:$PATH"
 	source "$FUNCTIONS_ONLY"
 	yes_flag=false
 	allow_keychain=false
 	SANDBOX_BACKEND="native"
-	payload_file="$TEST_ROOT/oauth_preemptive_payload.json"
-	expires_at=$((($(date +%s) + (11 * 60 * 60)) * 1000))
-	printf '{"expiresAt":%s}\n' "$expires_at" >"$payload_file"
+	payload_file="$TEST_ROOT/oauth_expired_payload.json"
+	expired_at=$((($(date +%s) - 60) * 1000))
+	fresh_at=4102444800000
+	refresh_attempts=0
+	printf '{"expiresAt":%s}\n' "$expired_at" >"$payload_file"
 	get_claude_credentials_payload() {
 		cat "$payload_file"
 	}
 	run_unsandboxed_claude_refresh() {
-		printf '{"expiresAt":4102444800000}\n' >"$payload_file"
+		refresh_attempts=$((refresh_attempts + 1))
+		printf '{"expiresAt":%s}\n' "$fresh_at" >"$payload_file"
 		return 0
 	}
 	ensure_refreshable_oauth_credentials
+	[[ "$refresh_attempts" -eq 1 ]]
 	[[ "$(cat "$payload_file")" == '{"expiresAt":4102444800000}' ]]
 ); then
-	pass "OAuth preflight refreshes automatically inside preemptive window"
+	pass "OAuth preflight repairs expired credentials before startup"
 else
-	fail "OAuth preflight refreshes automatically inside preemptive window"
+	fail "OAuth preflight repairs expired credentials before startup"
 fi
 
 echo ""
-echo "Test: OAuth preflight accepts still-valid credentials after no-op refresh"
-if (
-	PATH="$FAKE_BIN:$PATH"
-	source "$FUNCTIONS_ONLY"
-	yes_flag=false
-	allow_keychain=false
-	SANDBOX_BACKEND="native"
-	refresh_attempts=0
-	expires_at=$((($(date +%s) + (11 * 60 * 60)) * 1000))
-	get_claude_credentials_payload() {
-		printf '{"expiresAt":%s}\n' "$expires_at"
-	}
-	run_unsandboxed_claude_refresh() {
-		refresh_attempts=$((refresh_attempts + 1))
-		return 0
-	}
-	ensure_refreshable_oauth_credentials
-	[[ "$refresh_attempts" -eq 1 ]]
+echo "Test: OAuth preflight fails closed when expired refresh fails"
+if output=$(
+	PATH="$FAKE_BIN:$PATH" TEST_ROOT="$TEST_ROOT" FUNCTIONS_ONLY="$FUNCTIONS_ONLY" bash <<'EOF' 2>&1
+set -euo pipefail
+source "$FUNCTIONS_ONLY"
+yes_flag=false
+allow_keychain=false
+SANDBOX_BACKEND="native"
+expired_at=$((($(date +%s) - 60) * 1000))
+get_claude_credentials_payload() {
+	printf '{"expiresAt":%s}\n' "$expired_at"
+}
+get_claude_command() {
+	printf 'claude\n'
+}
+run_unsandboxed_claude_refresh() {
+	return 1
+}
+ensure_refreshable_oauth_credentials
+EOF
 ); then
-	pass "OAuth preflight accepts still-valid credentials after no-op refresh"
+	fail "OAuth preflight exits when expired refresh fails"
 else
-	fail "OAuth preflight accepts still-valid credentials after no-op refresh"
+	assert_contains "$output" "Claude OAuth refresh did not complete" "expired refresh failure explains failure"
+	assert_contains "$output" "Run plain \`claude\` to re-authenticate, then retry cco." "expired refresh failure prints reauth guidance"
 fi
 
 echo ""
-echo "Test: OAuth preflight continues after failed preemptive refresh with valid token"
+echo "Test: OAuth preflight fails closed when expired refresh remains expired"
+if output=$(
+	PATH="$FAKE_BIN:$PATH" TEST_ROOT="$TEST_ROOT" FUNCTIONS_ONLY="$FUNCTIONS_ONLY" bash <<'EOF' 2>&1
+set -euo pipefail
+source "$FUNCTIONS_ONLY"
+yes_flag=false
+allow_keychain=false
+SANDBOX_BACKEND="native"
+expired_at=$((($(date +%s) - 60) * 1000))
+get_claude_credentials_payload() {
+	printf '{"expiresAt":%s}\n' "$expired_at"
+}
+get_claude_command() {
+	printf 'claude\n'
+}
+run_unsandboxed_claude_refresh() {
+	return 0
+}
+ensure_refreshable_oauth_credentials
+EOF
+); then
+	fail "OAuth preflight exits when refreshed credentials remain expired"
+else
+	assert_contains "$output" "Claude OAuth credentials are still expired after the refresh attempt" "still-expired refresh explains failure"
+	assert_contains "$output" "Run plain \`claude\` to re-authenticate, then retry cco." "still-expired refresh prints reauth guidance"
+fi
+
+echo ""
+echo "Test: OAuth preflight backgrounds refresh for valid near-expiry credentials"
 if (
 	PATH="$FAKE_BIN:$PATH"
 	source "$FUNCTIONS_ONLY"
 	yes_flag=false
 	allow_keychain=false
 	SANDBOX_BACKEND="native"
-	refresh_attempts=0
-	expires_at=$((($(date +%s) + (11 * 60 * 60)) * 1000))
+	background_attempts=0
+	foreground_attempts=0
+	expires_at=$((($(date +%s) + (90 * 60)) * 1000))
 	get_claude_credentials_payload() {
 		printf '{"expiresAt":%s}\n' "$expires_at"
 	}
 	run_unsandboxed_claude_refresh() {
-		refresh_attempts=$((refresh_attempts + 1))
+		foreground_attempts=$((foreground_attempts + 1))
 		return 1
 	}
+	start_background_claude_refresh() {
+		background_attempts=$((background_attempts + 1))
+	}
 	ensure_refreshable_oauth_credentials
-	[[ "$refresh_attempts" -eq 1 ]]
+	[[ "$background_attempts" -eq 1 ]]
+	[[ "$foreground_attempts" -eq 0 ]]
 ); then
-	pass "OAuth preflight continues after failed preemptive refresh with valid token"
+	pass "OAuth preflight backgrounds refresh for valid near-expiry credentials"
 else
-	fail "OAuth preflight continues after failed preemptive refresh with valid token"
+	fail "OAuth preflight backgrounds refresh for valid near-expiry credentials"
 fi
 
 echo ""
-echo "Test: OAuth preflight skips refresh outside preemptive window"
+echo "Test: OAuth preflight skips refresh outside background window"
 if (
 	PATH="$FAKE_BIN:$PATH"
 	source "$FUNCTIONS_ONLY"
 	yes_flag=false
 	allow_keychain=false
 	SANDBOX_BACKEND="native"
-	refresh_attempts=0
-	expires_at=$((($(date +%s) + (13 * 60 * 60)) * 1000))
+	background_attempts=0
+	foreground_attempts=0
+	expires_at=$((($(date +%s) + (3 * 60 * 60)) * 1000))
 	get_claude_credentials_payload() {
 		printf '{"expiresAt":%s}\n' "$expires_at"
 	}
 	run_unsandboxed_claude_refresh() {
-		refresh_attempts=$((refresh_attempts + 1))
+		foreground_attempts=$((foreground_attempts + 1))
 		return 0
 	}
+	start_background_claude_refresh() {
+		background_attempts=$((background_attempts + 1))
+	}
 	ensure_refreshable_oauth_credentials
-	[[ "$refresh_attempts" -eq 0 ]]
+	[[ "$background_attempts" -eq 0 ]]
+	[[ "$foreground_attempts" -eq 0 ]]
 ); then
-	pass "OAuth preflight skips refresh outside preemptive window"
+	pass "OAuth preflight skips refresh outside background window"
 else
-	fail "OAuth preflight skips refresh outside preemptive window"
+	fail "OAuth preflight skips refresh outside background window"
 fi
 
 echo ""


### PR DESCRIPTION
## What changed

This PR replaces OAuth credential persistence with a startup repair model that avoids granting the sandboxed process broad home-directory or credential write access.

### Core fix
- **Replaced home-write OAuth persistence with startup refresh**: Instead of having sandboxed Claude write refreshed tokens back to the host's credential store, `cco` now repairs already-expired credentials before the sandbox starts. Valid credentials that are close to expiry are refreshed in the background on the host while startup continues.

### Regression coverage
- Added comprehensive test coverage for credential expiry scenarios (`tests/test_startup_preflights.sh`)
- Added regression tests for sandbox detection and git worktree support
- Covered indented `.env` comments in the native launcher

### Documentation
- Updated README and SECURITY.md to accurately reflect the startup OAuth maintenance model
- Clarified the startup refresh security posture and what `--yes` controls
- Documented that OAuth maintenance is a fixed, non-interactive `cco`-controlled action

### Bug fixes
- Fixed bubblewrap detection to happen before native sandbox selection (avoids false-positive native mode on blocked bubblewrap)
- Kept Claude OAuth preflight out of non-Claude modes (`cco codex`, `--command`, etc.)
- Split OAuth refresh into two distinct concerns: expired repair and background maintenance with appropriate timing

## Validation

- `tests/test_startup_preflights.sh` covers expired credentials, near-expiry refresh, and valid credential survival
- `tests/test_sandbox.sh` validates bubblewrap detection before sandbox selection
- `tests/test_git_worktree_support.sh` and `tests/test_env_flag.sh` cover adjacent paths

## Follow-up notes

- The experimental `--allow-oauth-refresh` flag still enables bidirectional credential sync for backends that support it
- The security model remains unchanged for backends that cannot safely persist an in-sandbox refresh
