### PR TITLE
Add --clean-old-images to remove old cco image tags after pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ cco --backend auto    # Auto-detect (default)
 # Rebuild the protective layer (Docker mode only, also updates to latest Claude Code version)
 cco --rebuild
 
+# Pull the latest pre-built image and automatically remove older cco image tags
+cco --pull --clean-old-images
+
 # System information and status
 cco --info
 
@@ -236,6 +239,7 @@ cco --deny-path ~/Downloads
 
 - `--docker-socket` (experimental): Binds the host Docker socket into the sandbox so Claude can control Docker on your machine. This defeats the isolation barrier—avoid unless you explicitly need host Docker access.
 - `--image IMAGE` / `--docker-image IMAGE` (Docker only): Runs `cco` against a specific Docker image instead of the default managed `cco:latest` image. This is useful if you `docker commit` a known-good persistent container yourself and want later `cco` runs to start from that image. With `--pull`, `cco` pulls the chosen image first.
+- `--clean-old-images` (Docker only): After a successful pre-built image pull, remove older `ghcr.io/nikvdp/cco:*` tags automatically. Without this flag, `cco` asks before removing old managed image tags when it can prompt.
 - `--force-docker-bridge-network` (Docker only): Force bridge networking instead of host networking. By default cco uses `--network=host` when available (Linux, OrbStack). Use this if you need port isolation or want explicit `-p` port forwarding.
 - `--yes` / `-y`: Auto-accept startup recovery prompts such as macOS Keychain unlock before `cco` starts. OAuth maintenance is automatic when needed and is not controlled by `--yes`.
 - `--allow-oauth-refresh` (experimental): Gives the container write access to your Claude credentials so refreshed tokens sync back to the host. Malicious prompts could corrupt or replace those credentials.

--- a/cco
+++ b/cco
@@ -1256,10 +1256,88 @@ pull_prebuilt_image() {
 		# Tag as local image name for consistency
 		docker tag "$image_tag" "$IMAGE_NAME" >/dev/null 2>&1
 		log "Successfully pulled pre-built image"
+		offer_old_cco_image_cleanup "$image_tag"
 		return 0
 	else
 		warn "Failed to pull pre-built image, building locally..."
 		return 1
+	fi
+}
+
+list_old_cco_image_refs() {
+	local current_tag="$1"
+	local image_ref
+
+	while IFS= read -r image_ref; do
+		if [[ "$image_ref" == "$current_tag" || "$image_ref" == "ghcr.io/nikvdp/cco:<none>" ]]; then
+			continue
+		fi
+
+		case "$image_ref" in
+		ghcr.io/nikvdp/cco:*)
+			printf '%s\n' "$image_ref"
+			;;
+		esac
+	done < <(docker image ls ghcr.io/nikvdp/cco --format '{{.Repository}}:{{.Tag}}' 2>/dev/null)
+}
+
+confirm_default_no() {
+	local prompt="$1"
+
+	if [[ -t 0 && -t 1 ]]; then
+		echo
+		read -p "$prompt [y/N] " -r
+		if [[ $REPLY =~ ^([Yy])$ ]]; then
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+remove_old_cco_images() {
+	local image_ref
+	local failed=false
+
+	for image_ref in "$@"; do
+		log "Removing old cco image tag: $image_ref"
+		if ! docker image rm "$image_ref" >/dev/null 2>&1; then
+			warn "Could not remove old cco image tag: $image_ref"
+			failed=true
+		fi
+	done
+
+	[[ "$failed" == false ]]
+}
+
+offer_old_cco_image_cleanup() {
+	local current_tag="$1"
+	local image_ref
+	local old_image_refs=()
+
+	while IFS= read -r image_ref; do
+		[[ -n "$image_ref" ]] && old_image_refs+=("$image_ref")
+	done < <(list_old_cco_image_refs "$current_tag")
+
+	if [[ ${#old_image_refs[@]} -eq 0 ]]; then
+		return 0
+	fi
+
+	warn "Found ${#old_image_refs[@]} old cco Docker image tag(s) from previous pulls"
+	for image_ref in "${old_image_refs[@]}"; do
+		warn "  $image_ref"
+	done
+
+	if [[ "$clean_old_images" == true ]]; then
+		remove_old_cco_images "${old_image_refs[@]}"
+		return
+	fi
+
+	if confirm_default_no "Remove these old cco Docker image tags now?"; then
+		remove_old_cco_images "${old_image_refs[@]}"
+	else
+		log "Keeping old cco Docker image tags"
+		log "Use --clean-old-images with pull or --pull to remove them automatically after a successful pull"
 	fi
 }
 
@@ -2698,6 +2776,7 @@ allow_keychain=false
 enable_background_tasks=false
 rebuild_image=false
 pull_image=false
+clean_old_images=false
 yes_flag=false
 shell_mode=false
 safe_mode=false
@@ -2771,6 +2850,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--pull)
 		pull_image=true
+		shift
+		;;
+	--clean-old-images)
+		clean_old_images=true
 		shift
 		;;
 	--docker-socket)
@@ -3104,6 +3187,7 @@ if [[ $# -gt 0 ]]; then
 		echo "Options:"
 		echo "  --rebuild             Force rebuild Docker image"
 		echo "  --pull                Pull latest image before starting"
+		echo "  --clean-old-images    Remove old cco image tags after a successful pull"
 		echo "  --yes, -y             Auto-accept startup recovery prompts"
 		echo "  --version, -v         Show version"
 		echo "  --env, -e KEY=VAL     Set container environment variable"

--- a/tests/test_startup_preflights.sh
+++ b/tests/test_startup_preflights.sh
@@ -147,6 +147,74 @@ else
 fi
 
 echo ""
+echo "Test: Docker image cleanup lists only old cco registry tags"
+if (
+	source "$FUNCTIONS_ONLY"
+	docker() {
+		if [[ "$*" == "image ls ghcr.io/nikvdp/cco --format {{.Repository}}:{{.Tag}}" ]]; then
+			printf '%s\n' \
+				"ghcr.io/nikvdp/cco:current" \
+				"ghcr.io/nikvdp/cco:old-one" \
+				"ghcr.io/nikvdp/cco:<none>" \
+				"other/repo:old"
+			return 0
+		fi
+		return 1
+	}
+	output=$(list_old_cco_image_refs "ghcr.io/nikvdp/cco:current")
+	[[ "$output" == "ghcr.io/nikvdp/cco:old-one" ]]
+); then
+	pass "Docker image cleanup lists only old managed registry tags"
+else
+	fail "Docker image cleanup lists only old managed registry tags"
+fi
+
+echo ""
+echo "Test: Docker image cleanup auto-removes old tags when flag is set"
+if (
+	source "$FUNCTIONS_ONLY"
+	clean_old_images=true
+	removed_refs=()
+	list_old_cco_image_refs() {
+		printf '%s\n' "ghcr.io/nikvdp/cco:old-one" "ghcr.io/nikvdp/cco:old-two"
+	}
+	remove_old_cco_images() {
+		removed_refs=("$@")
+	}
+	offer_old_cco_image_cleanup "ghcr.io/nikvdp/cco:current"
+	[[ ${#removed_refs[@]} -eq 2 ]]
+	[[ "${removed_refs[0]}" == "ghcr.io/nikvdp/cco:old-one" ]]
+	[[ "${removed_refs[1]}" == "ghcr.io/nikvdp/cco:old-two" ]]
+); then
+	pass "Docker image cleanup auto-removes old tags when flag is set"
+else
+	fail "Docker image cleanup auto-removes old tags when flag is set"
+fi
+
+echo ""
+echo "Test: Docker image cleanup skips removal without prompt confirmation"
+if (
+	source "$FUNCTIONS_ONLY"
+	clean_old_images=false
+	removed_count=0
+	list_old_cco_image_refs() {
+		printf '%s\n' "ghcr.io/nikvdp/cco:old-one"
+	}
+	confirm_default_no() {
+		return 1
+	}
+	remove_old_cco_images() {
+		removed_count=$((removed_count + $#))
+	}
+	offer_old_cco_image_cleanup "ghcr.io/nikvdp/cco:current"
+	[[ "$removed_count" -eq 0 ]]
+); then
+	pass "Docker image cleanup skips removal without prompt confirmation"
+else
+	fail "Docker image cleanup skips removal without prompt confirmation"
+fi
+
+echo ""
 echo "Test: OAuth preflight repairs expired credentials before startup"
 if (
 	PATH="$FAKE_BIN:$PATH"


### PR DESCRIPTION
## What

Adds a `--clean-old-images` flag that removes old `ghcr.io/nikvdp/cco:*` image tags after a successful `pull_prebuilt_image()`.

## Changes

- **new `list_old_cco_image_refs()`** — filters Docker image list to only emit `ghcr.io/nikvdp/cco:*` refs, skipping the freshly-pulled tag and the `<none>` dangling entry
- **new `confirm_default_no()`** — shared yes/no prompt with defaulting to no (used for preflight and now reused for image cleanup)
- **new `remove_old_cco_images()`** — iterates and removes each given ref, logging warnings on failure
- **new `offer_old_cco_image_cleanup()`** — orchestrates listing → warning → conditional removal (auto via `--clean-old-images`, or interactive via `confirm_default_no`)
- **call site** in `pull_prebuilt_image()` — invokes `offer_old_cco_image_cleanup` after a successful pull
- **CLI flag** `--clean-old-images` sets `clean_old_images=true`
- **README update** — documents the new flag and a combined `--pull --clean-old-images` usage example

## Tests

Covers three cases:
1. `list_old_cco_image_refs` only emits old `ghcr.io/nikvdp/cco:*` tags
2. Auto-removal fires when `clean_old_images=true`
3. Removal is skipped when `clean_old_images=false` and the user declines

## Notes

- Failing individual removals is non-fatal — other old tags still attempt cleanup
- The `<none>` (dangling) entry is always skipped to avoid unexpected pruning
- Related: docs already mention `cco --rebuild`; this provides a pull-equivalent cleanup path
