### PR TITLE
Support x-agent harness

### DIFF
--- a/cco
+++ b/cco
@@ -69,7 +69,7 @@ is_valid_persist_name() {
 
 is_known_subcommand() {
 	case "$1" in
-	shell | codex | droid | opencode | pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
+	shell | codex | droid | opencode | pi | my-pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
 		return 0
 		;;
 	*)
@@ -3300,7 +3300,7 @@ while [[ $# -gt 0 ]]; do
 			while [[ $# -gt 0 ]] && [[ ! "$1" =~ ^- ]]; do
 				# Stop if we hit a known subcommand
 				case "$1" in
-				shell | codex | droid | opencode | pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
+				shell | codex | droid | opencode | pi | my-pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
 					# This is a subcommand, not a directory
 					break
 					;;
@@ -3373,6 +3373,12 @@ if [[ $# -gt 0 ]]; then
 		configure_agent_subcommand "pi"
 		shift
 		# All remaining arguments are passed to pi
+		claude_args=("$@")
+		;;
+	my-pi)
+		configure_agent_subcommand "my-pi"
+		shift
+		# All remaining arguments are passed to my-pi
 		claude_args=("$@")
 		;;
 	gemini)
@@ -3455,6 +3461,7 @@ if [[ $# -gt 0 ]]; then
 		echo "  droid [args...]     Run Droid CLI in sandbox"
 		echo "  opencode [args...]  Run OpenCode in sandbox"
 		echo "  pi [args...]        Run Pi coding agent in sandbox"
+	echo "  my-pi [args...]     Run My Pi coding agent in sandbox"
 		echo "  gemini [args...]    Run Google Gemini CLI in sandbox"
 		echo "  cleanup             Remove all cco containers"
 		echo "  info                Show system info and readiness"

--- a/cco
+++ b/cco
@@ -3461,7 +3461,7 @@ if [[ $# -gt 0 ]]; then
 		echo "  droid [args...]     Run Droid CLI in sandbox"
 		echo "  opencode [args...]  Run OpenCode in sandbox"
 		echo "  pi [args...]        Run Pi coding agent in sandbox"
-	echo "  my-pi [args...]     Run My Pi coding agent in sandbox"
+		echo "  my-pi [args...]     Run My Pi coding agent in sandbox"
 		echo "  gemini [args...]    Run Google Gemini CLI in sandbox"
 		echo "  cleanup             Remove all cco containers"
 		echo "  info                Show system info and readiness"

--- a/cco
+++ b/cco
@@ -1650,7 +1650,7 @@ build_image() {
 	# Build from the directory containing the cco script
 	cd "$CCO_INSTALLATION_DIR" || {
 		error "cco installation not found at $CCO_INSTALLATION_DIR"
-		error "Run: curl -fsSL https://raw.githubusercontent.com/nikvdp/cco/master/install.sh | bash"
+		error "Run: curl -fsSL https://raw.githubusercontent.com/antony/cco/master/install.sh | bash"
 		exit 1
 	}
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ info() {
 }
 
 # Configuration
-GITHUB_REPO="nikvdp/cco"
+GITHUB_REPO="antony/cco"
 GITHUB_SSH_URL="git@github.com:${GITHUB_REPO}.git"
 GITHUB_HTTPS_URL="https://github.com/${GITHUB_REPO}.git"
 CCO_INSTALLATION_DIR="$HOME/.local/share/cco"

--- a/install.sh
+++ b/install.sh
@@ -297,7 +297,7 @@ case "${1:-}" in
 --help | -h)
 	echo "cco installer - a thin protective layer for Claude Code"
 	echo ""
-	echo "Usage: curl -fsSL https://raw.githubusercontent.com/nikvdp/cco/master/install.sh | bash"
+	echo "Usage: curl -fsSL https://raw.githubusercontent.com/antony/cco/master/install.sh | bash"
 	echo ""
 	echo "This script will:"
 	echo "  • Clone cco to ~/.local/share/cco"

--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -9,6 +9,8 @@ source "$CCO_INSTALLATION_DIR/lib/agents/opencode.sh"
 # shellcheck source=/dev/null
 source "$CCO_INSTALLATION_DIR/lib/agents/pi.sh"
 # shellcheck source=/dev/null
+source "$CCO_INSTALLATION_DIR/lib/agents/my_pi.sh"
+# shellcheck source=/dev/null
 source "$CCO_INSTALLATION_DIR/lib/agents/gemini.sh"
 
 configure_agent_subcommand() {

--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -31,6 +31,10 @@ configure_agent_subcommand() {
 		command_flag="pi"
 		configure_pi_mode_paths
 		;;
+	my-pi)
+		command_flag="my-pi"
+		configure_my_pi_mode_paths
+		;;
 	gemini)
 		command_flag="gemini --yolo"
 		configure_gemini_mode_paths
@@ -63,6 +67,9 @@ apply_agent_arg_policies() {
 		;;
 	pi)
 		apply_pi_arg_policies
+		;;
+	my-pi)
+		apply_my_pi_arg_policies
 		;;
 	gemini)
 		apply_gemini_arg_policies

--- a/lib/agents/my_pi.sh
+++ b/lib/agents/my_pi.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+configure_my_pi_mode_paths() {
+	if [[ -d "$HOME/.pi" ]]; then
+		add_rw_path "$HOME/.pi"
+	fi
+}
+
+apply_my_pi_arg_policies() {
+	:
+}

--- a/lib/agents/pi.sh
+++ b/lib/agents/pi.sh
@@ -10,12 +10,3 @@ apply_pi_arg_policies() {
 	:
 }
 
-configure_my_pi_mode_paths() {
-	if [[ -d "$HOME/.my-pi" ]]; then
-		add_rw_path "$HOME/.my-pi"
-	fi
-}
-
-apply_my_pi_arg_policies() {
-	:
-}

--- a/lib/agents/pi.sh
+++ b/lib/agents/pi.sh
@@ -9,3 +9,13 @@ configure_pi_mode_paths() {
 apply_pi_arg_policies() {
 	:
 }
+
+configure_my_pi_mode_paths() {
+	if [[ -d "$HOME/.my-pi" ]]; then
+		add_rw_path "$HOME/.my-pi"
+	fi
+}
+
+apply_my_pi_arg_policies() {
+	:
+}


### PR DESCRIPTION
So I'm opening this partly because I use it, and partly because I think it demonstrates a flaw with CCO which I think can be improved - namely, the supported harnesses are hard-coded, and I think we could benefit from an abstraction, to allow a form of 'plugin' to add harnesses, rather than forever hardcode them in across six different files.

I notice the entire sandbox is written in bash, and I certainly don't have the bash foo to conceive of the correct architecture for this, but I think it would benefit future users.

Leaving this PR here for reference, and as a start-point for discussion. Obviously not intended for merge, since I had to actually update the GitHub repository URL in order for the install script to work.