### PR TITLE
Adds `cco auto <model>` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,21 @@ cco --add-dir ~/.codex --command "codex --dangerously-bypass-approvals-and-sandb
 
 Security note: `--dangerously-bypass-approvals-and-sandbox` applies to Codex’s internal permission checks, not to `cco`. The `cco` sandbox still constrains filesystem access to your project and explicitly mounted paths. Network access remains unrestricted by design.
 
+### Auto Mode (`cco auto <agent>`)
+
+`cco auto <agent>` runs an agent in its native "ask me when it matters" mode instead of the default full-bypass mode:
+
+- `cco auto claude` runs Claude with `--permission-mode auto` instead of `--dangerously-skip-permissions`.
+- `cco auto codex` runs Codex with `--ask-for-approval on-request` instead of `--dangerously-bypass-approvals-and-sandbox`.
+- For all other agents (`gemini`, `droid`, `opencode`, `pi`) it behaves exactly like running the agent normally.
+
+In every case `cco`'s sandbox still applies; auto mode only changes the agent's own permission posture.
+
+```bash
+cco auto claude "refactor this module"
+cco auto codex "build and run the tests"
+```
+
 ## MCP Server Support
 
 `cco` uses host-based networking so that MCP (Model Context Protocol) servers or other tools you may have running on localhost are accessible to `cco`.

--- a/cco
+++ b/cco
@@ -69,7 +69,7 @@ is_valid_persist_name() {
 
 is_known_subcommand() {
 	case "$1" in
-	shell | codex | droid | opencode | pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
+	shell | auto | codex | droid | opencode | pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
 		return 0
 		;;
 	*)
@@ -549,6 +549,11 @@ build_claude_permission_args() {
 	claude_permission_args=()
 
 	if claude_args_include_permission_mode; then
+		return
+	fi
+
+	if [[ "${auto_mode:-}" == true ]]; then
+		claude_permission_args=("--permission-mode" "auto")
 		return
 	fi
 
@@ -2273,6 +2278,7 @@ run_container() {
 		fi
 		add_mount_arg "$codex_shim_dir" "$codex_shim_dir" "ro"
 		docker_args+=(-e "CCO_PREPEND_PATH=$codex_shim_dir")
+		docker_args+=(-e "CCO_CODEX_AUTO_MODE=$auto_mode")
 		persistent_exec_path="$codex_shim_dir:$persistent_exec_path"
 		log "Enabled codex-mode PATH shim for nested codex invocations"
 	fi
@@ -3069,6 +3075,7 @@ enable_git_worktree_common_dir=true
 claude_command_flag=""
 command_flag=""
 codex_mode=false
+auto_mode=false
 
 if [[ "${CCO_ALLOW_EXTERNAL_GIT_DIR:-}" == "1" ]]; then
 	allow_external_git_dir=true
@@ -3300,7 +3307,7 @@ while [[ $# -gt 0 ]]; do
 			while [[ $# -gt 0 ]] && [[ ! "$1" =~ ^- ]]; do
 				# Stop if we hit a known subcommand
 				case "$1" in
-				shell | codex | droid | opencode | pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
+				shell | auto | codex | droid | opencode | pi | gemini | self-update | cleanup | info | backup-creds | restore-creds | pull | rebuild)
 					# This is a subcommand, not a directory
 					break
 					;;
@@ -3346,6 +3353,26 @@ if [[ $# -gt 0 ]]; then
 		shift
 		# All remaining arguments are shell command arguments
 		claude_args=("$@")
+		;;
+	auto)
+		# Auto mode: run the named agent in its CLI's "ask me when needed" mode instead of a full permission bypass.
+		auto_mode=true
+		shift # consume "auto"
+		case "${1:-claude}" in
+		claude)
+			[[ $# -gt 0 ]] && shift # drop the explicit "claude" agent name when present
+			claude_args=("$@")
+			;;
+		codex | droid | opencode | pi | gemini)
+			configure_agent_subcommand "$1"
+			shift
+			claude_args=("$@")
+			;;
+		*)
+			# No explicit/recognized agent: treat the rest as Claude args.
+			claude_args=("$@")
+			;;
+		esac
 		;;
 	codex)
 		# OpenAI Codex mode - set up the command and add default directory
@@ -3456,6 +3483,7 @@ if [[ $# -gt 0 ]]; then
 		echo "  opencode [args...]  Run OpenCode in sandbox"
 		echo "  pi [args...]        Run Pi coding agent in sandbox"
 		echo "  gemini [args...]    Run Google Gemini CLI in sandbox"
+		echo "  auto <agent> [args] Run an agent in auto mode (asks when needed, not full bypass)"
 		echo "  cleanup             Remove all cco containers"
 		echo "  info                Show system info and readiness"
 		echo "  pull                Pull latest pre-built image"

--- a/lib/agents/codex.sh
+++ b/lib/agents/codex.sh
@@ -89,7 +89,12 @@ apply_codex_arg_policies() {
 		return
 	fi
 
-	if ! codex_args_contain_any "${claude_args[@]}" -- "--dangerously-bypass-approvals-and-sandbox"; then
+	if [[ "${auto_mode:-}" == true ]]; then
+		if ! codex_args_contain_any "${claude_args[@]}" -- "--ask-for-approval" "-a"; then
+			claude_args=("--ask-for-approval" "on-request" "${claude_args[@]}")
+			log "Added Codex auto-mode flag '--ask-for-approval on-request'"
+		fi
+	elif ! codex_args_contain_any "${claude_args[@]}" -- "--dangerously-bypass-approvals-and-sandbox"; then
 		claude_args=("--dangerously-bypass-approvals-and-sandbox" "${claude_args[@]}")
 		log "Added Codex bypass flag '--dangerously-bypass-approvals-and-sandbox'"
 	fi
@@ -178,6 +183,13 @@ while [[ $# -gt 0 ]]; do
 	--sandbox=*)
 		shift
 		;;
+	-a | --ask-for-approval)
+		shift
+		[[ $# -gt 0 ]] && shift
+		;;
+	--ask-for-approval=*)
+		shift
+		;;
 	-c | --config)
 		if [[ $# -gt 1 && "$2" == sandbox_mode=* ]]; then
 			shift 2
@@ -198,8 +210,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 cmd=("$real_codex")
-if [[ "$saw_bypass" != true && "$requests_help_or_version" != true ]]; then
-	cmd+=("--dangerously-bypass-approvals-and-sandbox")
+if [[ "$requests_help_or_version" != true ]]; then
+	if [[ "${CCO_CODEX_AUTO_MODE:-}" == true ]]; then
+		cmd+=("--ask-for-approval" "on-request" "--sandbox" "danger-full-access")
+	elif [[ "$saw_bypass" != true ]]; then
+		cmd+=("--dangerously-bypass-approvals-and-sandbox")
+	fi
 fi
 cmd+=("${filtered_args[@]}")
 exec "${cmd[@]}"

--- a/tests/test_startup_preflights.sh
+++ b/tests/test_startup_preflights.sh
@@ -335,6 +335,59 @@ else
 fi
 
 echo ""
+echo "Test: cco auto mode requests Claude --permission-mode auto"
+if (
+	source "$FUNCTIONS_ONLY"
+	auto_mode=true
+	claude_args=()
+	claude_permission_args=(stale)
+	build_claude_permission_args
+	[[ ${#claude_permission_args[@]} -eq 2 ]]
+	[[ "${claude_permission_args[0]}" == "--permission-mode" ]]
+	[[ "${claude_permission_args[1]}" == "auto" ]]
+); then
+	pass "cco auto mode requests Claude --permission-mode auto"
+else
+	fail "cco auto mode requests Claude --permission-mode auto"
+fi
+
+echo ""
+echo "Test: cco auto mode gives Codex --ask-for-approval on-request"
+if (
+	source "$FUNCTIONS_ONLY"
+	auto_mode=true
+	codex_mode=true
+	command_flag="codex"
+	SANDBOX_BACKEND="native"
+	claude_args=("hi")
+	apply_codex_arg_policies
+	[[ "${claude_args[0]}" == "--ask-for-approval" ]]
+	[[ "${claude_args[1]}" == "on-request" ]]
+	! printf '%s\n' "${claude_args[@]}" | grep -qx -- "--dangerously-bypass-approvals-and-sandbox"
+); then
+	pass "cco auto mode gives Codex --ask-for-approval on-request"
+else
+	fail "cco auto mode gives Codex --ask-for-approval on-request"
+fi
+
+echo ""
+echo "Test: Codex without auto mode keeps the bypass flag"
+if (
+	source "$FUNCTIONS_ONLY"
+	auto_mode=false
+	codex_mode=true
+	command_flag="codex"
+	SANDBOX_BACKEND="native"
+	claude_args=("hi")
+	apply_codex_arg_policies
+	[[ "${claude_args[0]}" == "--dangerously-bypass-approvals-and-sandbox" ]]
+); then
+	pass "Codex without auto mode keeps the bypass flag"
+else
+	fail "Codex without auto mode keeps the bypass flag"
+fi
+
+echo ""
 echo "Test: additionalDirectories is silent when key is absent"
 if output=$(
 	TEST_ROOT="$TEST_ROOT" FUNCTIONS_ONLY="$FUNCTIONS_ONLY" bash <<'EOF' 2>&1


### PR DESCRIPTION
New command uses claude or codex's auto mode instead of the default
no-permissions mode. No changes for any other model.